### PR TITLE
Fix select() sematics

### DIFF
--- a/src/render-dom.js
+++ b/src/render-dom.js
@@ -243,7 +243,6 @@ function makeFindElements(namespace) {
     if (namespace.join(``) === ``) {
       return rootElement
     }
-    const slice = Array.prototype.slice
     const scope = getScope(namespace)
     // Uses universal selector && is isolated
     if (namespace.indexOf(`*`) > -1 && scope.length > 0) {
@@ -256,14 +255,14 @@ function makeFindElements(namespace) {
       // grab all children
       const childNodes = topNode.getElementsByTagName(`*`)
       return removeDuplicates(
-        [topNode].concat(slice.call(childNodes))
+        [topNode].concat(Array.prototype.slice.call(childNodes))
       ).filter(makeIsStrictlyInRootScope(namespace))
     }
 
     return removeDuplicates(
-      slice.call(
+       Array.prototype.slice.call(
         rootElement.querySelectorAll(namespace.join(` `))
-      ).concat(slice.call(
+      ).concat(Array.prototype.slice.call(
         rootElement.querySelectorAll(namespace.join(``))
       ))
     ).filter(makeIsStrictlyInRootScope(namespace))

--- a/src/render-dom.js
+++ b/src/render-dom.js
@@ -215,8 +215,8 @@ const isValidString = param => typeof param === `string` && param.length > 0
 const contains = (str, match) => str.indexOf(match) > -1
 
 const isNotTagName = param =>
-    isValidString(param) && contains(param, `.`) ||
-    contains(param, `#`) || contains(param, `:`)
+  isValidString(param) && contains(param, `.`) ||
+  contains(param, `#`) || contains(param, `:`)
 
 function sortNamespace(a, b) {
   if (isNotTagName(a) && isNotTagName(b)) {

--- a/src/render-dom.js
+++ b/src/render-dom.js
@@ -210,8 +210,68 @@ function makeEventsSelector(rootEl$, namespace) {
   }
 }
 
-function makeElementSelector(rootEl$) {
-  return function select(selector) {
+const isValidString = param => typeof param === `string` && param.length > 0
+
+const contains = (str, match) => str.indexOf(match) > -1
+
+const isNotTagName = param =>
+    isValidString(param) && contains(param, `.`) ||
+    contains(param, `#`) || contains(param, `:`)
+
+function sortNamespace(a, b) {
+  if (isNotTagName(a) && isNotTagName(b)) {
+    return 0
+  }
+  return isNotTagName(a) ? 1 : -1
+}
+
+function removeDuplicates(arr) {
+  const newArray = []
+  arr.forEach((element) => {
+    if (newArray.indexOf(element) === -1) {
+      newArray.push(element)
+    }
+  })
+  return newArray
+}
+
+const getScope = namespace =>
+  namespace.filter(c => c.indexOf(`.cycle-scope`) > -1)
+
+function makeFindElements(namespace) {
+  return function findElements(rootElement) {
+    if (namespace.join(``) === ``) {
+      return rootElement
+    }
+    const slice = Array.prototype.slice
+    const scope = getScope(namespace)
+    // Uses universal selector && is isolated
+    if (namespace.indexOf(`*`) > -1 && scope.length > 0) {
+      // grab top-level boundary of scope
+      const topNode = rootElement.querySelector(scope.join(` `))
+
+      if (!topNode) {
+        return []
+      }
+      // grab all children
+      const childNodes = topNode.getElementsByTagName(`*`)
+      return removeDuplicates(
+        [topNode].concat(slice.call(childNodes))
+      ).filter(makeIsStrictlyInRootScope(namespace))
+    }
+
+    return removeDuplicates(
+      slice.call(
+        rootElement.querySelectorAll(namespace.join(` `))
+      ).concat(slice.call(
+        rootElement.querySelectorAll(namespace.join(``))
+      ))
+    ).filter(makeIsStrictlyInRootScope(namespace))
+  }
+}
+
+function makeElementSelector(rootElement$) {
+  return function elementSelector(selector) {
     if (typeof selector !== `string`) {
       throw new Error(`DOM driver's select() expects the argument to be a ` +
         `string as a CSS selector`)
@@ -221,23 +281,13 @@ function makeElementSelector(rootEl$) {
     const trimmedSelector = selector.trim()
     const childNamespace = trimmedSelector === `:root` ?
       namespace :
-      namespace.concat(trimmedSelector)
-    const element$ = rootEl$.map(rootEl => {
-      if (childNamespace.join(``) === ``) {
-        return rootEl
-      }
-      let nodeList = rootEl.querySelectorAll(childNamespace.join(` `))
-      if (nodeList.length === 0) {
-        nodeList = rootEl.querySelectorAll(childNamespace.join(``))
-      }
-      const array = Array.prototype.slice.call(nodeList)
-      return array.filter(makeIsStrictlyInRootScope(childNamespace))
-    })
+      namespace.concat(trimmedSelector).sort(sortNamespace)
+
     return {
-      observable: element$,
+      observable: rootElement$.map(makeFindElements(childNamespace)),
       namespace: childNamespace,
-      select: makeElementSelector(rootEl$),
-      events: makeEventsSelector(rootEl$, childNamespace),
+      select: makeElementSelector(rootElement$),
+      events: makeEventsSelector(rootElement$, childNamespace),
       isolateSource,
       isolateSink,
     }

--- a/test/browser/isolation.js
+++ b/test/browser/isolation.js
@@ -401,4 +401,111 @@ describe('isolation', function () {
       done();
     });
   });
+
+  it('should allow DOM.select()ing its own root without classname or id', function(done) {
+    function app(sources) {
+      return {
+        DOM: Rx.Observable.just(
+          h3('.top-most', [
+            sources.DOM.isolateSink(Rx.Observable.just(
+              span([
+                h4('.bar', 'Wrong')
+              ])
+            ), 'ISOLATION')
+          ])
+        )
+      };
+    }
+
+    const {sinks, sources} = Cycle.run(app, {
+      DOM: makeDOMDriver(createRenderTarget())
+    });
+
+    const {isolateSource} = sources.DOM;
+
+    isolateSource(sources.DOM, 'ISOLATION')
+      .select('span').observable
+      .skip(1)
+      .take(1)
+      .subscribe(function (elements) {
+        assert.strictEqual(Array.isArray(elements), true);
+        assert.strictEqual(elements.length, 1);
+        const correctElement = elements[0];
+        assert.notStrictEqual(correctElement, null);
+        assert.notStrictEqual(typeof correctElement, 'undefined');
+        assert.strictEqual(correctElement.tagName, 'SPAN');
+        done();
+      });
+  });
+
+  it('should allow DOM.select()ing all elements with `*`', function(done) {
+    function app(sources) {
+      return {
+        DOM: Rx.Observable.just(
+          h3('.top-most', [
+            sources.DOM.isolateSink(Rx.Observable.just(
+              span([
+                div([
+                  h4('.foo', 'hello'),
+                  h4('.bar', 'world')
+                ])
+              ])
+            ), 'ISOLATION')
+          ])
+        )
+      };
+    }
+
+    const {sinks, sources} = Cycle.run(app, {
+      DOM: makeDOMDriver(createRenderTarget())
+    });
+
+    const {isolateSource} = sources.DOM;
+
+    isolateSource(sources.DOM, 'ISOLATION')
+      .select('*').observable
+      .skip(1)
+      .take(1)
+      .subscribe(function (elements) {
+        assert.strictEqual(Array.isArray(elements), true);
+        assert.strictEqual(elements.length, 4);
+        done();
+      });
+  });
+
+  it('should select() isolated element with tag + class', function (done) {
+    function app() {
+      return {
+        DOM: Rx.Observable.just(
+          h3('.top-most', [
+            h2('.bar', 'Wrong'),
+            div('.cycle-scope-foo', [
+              h4('.bar', 'Correct')
+            ])
+          ])
+        )
+      };
+    }
+
+    const {sinks, sources} = Cycle.run(app, {
+      DOM: makeDOMDriver(createRenderTarget())
+    });
+    const isolatedDOMSource = sources.DOM.isolateSource(sources.DOM, 'foo');
+
+    // Make assertions
+    isolatedDOMSource
+      .select('h4.bar').observable
+      .skip(1)
+      .take(1)
+      .subscribe(function(elements) {
+        assert.strictEqual(elements.length, 1);
+        const correctElement = elements[0];
+        assert.notStrictEqual(correctElement, null);
+        assert.notStrictEqual(typeof correctElement, 'undefined');
+        assert.strictEqual(correctElement.tagName, 'H4');
+        assert.strictEqual(correctElement.textContent, 'Correct');
+        sources.dispose();
+        done();
+      });
+  });
 });

--- a/test/browser/select.js
+++ b/test/browser/select.js
@@ -156,4 +156,88 @@ describe('DOMSource.select()', function () {
         done();
       });
   });
+
+  it('should allow DOM.select()ing its own root without classname or id', function(done) {
+    function app(sources) {
+      return {
+        DOM: Rx.Observable.just(
+          h3([
+            span([
+              h4('.bar', 'hello')
+            ])
+          ])
+        )
+      };
+    }
+
+    const {sinks, sources} = Cycle.run(app, {
+      DOM: makeDOMDriver(createRenderTarget())
+    });
+
+    sources.DOM.select('h3').observable.skip(1).take(1).subscribe(function (elements) {
+      assert.strictEqual(Array.isArray(elements), true);
+      assert.strictEqual(elements.length, 1);
+      const correctElement = elements[0];
+      assert.notStrictEqual(correctElement, null);
+      assert.notStrictEqual(typeof correctElement, 'undefined');
+      assert.strictEqual(correctElement.tagName, 'H3');
+      done();
+    });
+  });
+
+  it('should allow DOM.select()ing all elements with `*`', function(done) {
+    function app(sources) {
+      return {
+        DOM: Rx.Observable.just(
+          h3('.top-most', [
+            span([
+              h4('.bar', 'hello')
+            ])
+          ])
+        )
+      };
+    }
+
+    const {sinks, sources} = Cycle.run(app, {
+      DOM: makeDOMDriver(createRenderTarget())
+    });
+
+
+     sources.DOM.select('*').observable.skip(1).take(1).subscribe(function (elements) {
+      assert.strictEqual(Array.isArray(elements), true);
+      assert.strictEqual(elements.length, 3);
+      done();
+    });
+  });
+
+ it('should select() isolated element with tag + class', function (done) {
+   function app() {
+     return {
+       DOM: Rx.Observable.just(
+         h3('.top-most', [
+           h2('.bar', 'Wrong'),
+           div([
+             h4('.bar', 'Correct')
+           ])
+         ])
+       )
+     };
+   };
+
+   const {sinks, sources} = Cycle.run(app, {
+     DOM: makeDOMDriver(createRenderTarget())
+   });
+
+   // Make assertions
+   sources.DOM.select('h4.bar').observable.skip(1).take(1).subscribe(function(elements) {
+     assert.strictEqual(elements.length, 1);
+     const correctElement = elements[0];
+     assert.notStrictEqual(correctElement, null);
+     assert.notStrictEqual(typeof correctElement, 'undefined');
+     assert.strictEqual(correctElement.tagName, 'H4');
+     assert.strictEqual(correctElement.textContent, 'Correct');
+     sources.dispose();
+     done();
+   });
+ });
 });


### PR DESCRIPTION
Add tests for select()ing tagName, tagName + selector, and '*' both in and out of
isolatation.

Fix for select()ing a tagName at the root of isolation
Fix for using `*` to select() all nodes under isolation

Closes #96 