### PR TITLE
feat(): update to work with cycle diversity

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,9 @@
     "rx": "*"
   },
   "devDependencies": {
-    "@cycle/core": "6.0.3",
-    "@cycle/base": "^1.3.1",
+    "@cycle/base": "^2.0.1",
+    "@cycle/rx-run": "7.0.0-rc3",
+    "@cycle/rxjs-run": "^1.0.2",
     "assert": "^1.3.0",
     "babel-cli": "^6.4.5",
     "babel-core": "^6.4.5",
@@ -61,6 +62,7 @@
     "markdox": "0.1.10",
     "mocha": "2.3.4",
     "rx": "4.0.7",
+    "rxjs": "^5.0.0-beta.5",
     "snabbdom-jsx": "^0.3.0",
     "testem": "0.9.11",
     "tslint": "3.6.0",

--- a/src/custom-typings/snabbdom.d.ts
+++ b/src/custom-typings/snabbdom.d.ts
@@ -1,7 +1,7 @@
 declare module 'snabbdom' {
   export interface VNode {
     sel?: string;
-    data?: Object;
+    data?: any;
     children?: Array<VNode | string>;
     text?: string;
     key?: any;

--- a/src/isolate.ts
+++ b/src/isolate.ts
@@ -1,4 +1,4 @@
-import {Observable} from 'rx';
+import {VNode} from 'snabbdom';
 import {SCOPE_PREFIX} from './utils';
 import {DOMSource} from './DOMSource';
 
@@ -6,8 +6,12 @@ export function isolateSource(source: DOMSource, scope: string): DOMSource {
   return source.select(`.${SCOPE_PREFIX}${scope}`);
 }
 
-export function isolateSink(sink: Observable<any>, scope: string): Observable<any> {
-  return sink.map(vTree => {
+interface Mappable<T, R> {
+  map(mapFn: (x: T) => R): Mappable<R, any>;
+}
+
+export function isolateSink(sink: any, scope: string): any {
+  return <Mappable<VNode, VNode>>sink.map((vTree: VNode) => {
     if (vTree.sel.indexOf(`${SCOPE_PREFIX}${scope}`) === -1) {
       if (vTree.data && vTree.data.ns) { // svg elements
         const attrs = vTree.data.attrs || {};

--- a/src/makeDOMDriver.ts
+++ b/src/makeDOMDriver.ts
@@ -1,3 +1,5 @@
+import {StreamAdapter} from '@cycle/base';
+
 import {init} from 'snabbdom';
 import {Observable} from 'rx';
 import {DOMSource} from './DOMSource';
@@ -49,10 +51,10 @@ function makeDOMDriver(container: string | Element, options?: DOMDriverOptions):
   const vnodeWrapper = new VNodeWrapper(rootElement);
   makeDOMDriverInputGuard(modules, onError);
 
-  function DOMDriver(vnode$: Observable<any>): DOMSource {
+  function DOMDriver(vnode$: Observable<any>, runStreamAdapter: StreamAdapter): DOMSource {
     domDriverInputGuard(vnode$);
     const goodVNode$ = (
-      transposition ? vnode$.flatMapLatest(transposeVTree) : vnode$
+      transposition ? vnode$.map(transposeVTree).switch() : vnode$
     );
     const rootElement$ = goodVNode$
       .map(vnodeWrapper.call, vnodeWrapper)
@@ -64,7 +66,7 @@ function makeDOMDriver(container: string | Element, options?: DOMDriverOptions):
 
     const disposable = rootElement$.connect();
 
-    return new DOMSource(rootElement$, [], disposable);
+    return new DOMSource(rootElement$, runStreamAdapter, [], disposable);
   };
 
   (<any> DOMDriver).streamAdapter = RxAdapter;

--- a/src/makeHTMLDriver.ts
+++ b/src/makeHTMLDriver.ts
@@ -6,7 +6,7 @@ const toHTML: (vnode: VNode) => string = require('snabbdom-to-html');
 function makeBogusSelect() {
   return function select() {
     return {
-      observable: Observable.empty(),
+      element$: Observable.empty(),
       events() {
         return Observable.empty();
       },

--- a/src/mockDOMSource.ts
+++ b/src/mockDOMSource.ts
@@ -1,18 +1,18 @@
 import {Observable} from 'rx';
 
 export interface DOMSelection {
-  observable: Observable<any>;
+  element$: Observable<any>;
   events: (eventType: string) => Observable<any>;
 }
 
 export class MockedDOMSource {
-  public observable: Observable<any>;
+  public element$: Observable<any>;
 
   constructor(private _mockConfig: Object) {
-    if (_mockConfig['observable']) {
-      this.observable = _mockConfig['observable'];
+    if (_mockConfig['element$']) {
+      this.element$ = _mockConfig['element$'];
     } else {
-      this.observable = Observable.empty();
+      this.element$ = Observable.empty();
     }
   }
 

--- a/src/transposition.ts
+++ b/src/transposition.ts
@@ -18,7 +18,7 @@ export function transposeVTree(vnode: any) {
   } else if (vnode && typeof vnode.data === `object` && vnode.data.static) {
     return Observable.of(vnode);
   } else if (typeof vnode.subscribe === `function`) {
-    return vnode.flatMapLatest(transposeVTree);
+    return vnode.map(transposeVTree).switch();
   } else if (typeof vnode === `object`) {
     if (!vnode.children || vnode.children.length === 0) {
       return Observable.of(vnode);

--- a/test/browser/index.js
+++ b/test/browser/index.js
@@ -1,7 +1,17 @@
 'use strict';
-require('./dom-driver.js');
-require('./render.js');
-require('./transposition.js');
-require('./select.js');
-require('./events.js');
-require('./isolation.js');
+
+// Rx 4
+require('./rx/dom-driver.js');
+require('./rx/render.js');
+require('./rx/transposition.js');
+require('./rx/select.js');
+require('./rx/events.js');
+require('./rx/isolation.js');
+
+// Rx 5
+require('./rxjs/dom-driver.js');
+require('./rxjs/render.js');
+require('./rxjs/transposition.js');
+require('./rxjs/select.js');
+require('./rxjs/events.js');
+require('./rxjs/isolation.js');

--- a/test/browser/rx/dom-driver.js
+++ b/test/browser/rx/dom-driver.js
@@ -1,0 +1,159 @@
+'use strict';
+/* global describe, it */
+let assert = require('assert');
+let Cycle = require('@cycle/rx-run').default;
+let CycleDOM = require('../../../lib/index');
+let Fixture89 = require('./fixtures/issue-89');
+let Rx = require('rx');
+let {h, svg, div, input, p, span, h2, h3, h4, select, option, makeDOMDriver} = CycleDOM;
+
+function createRenderTarget(id = null) {
+  let element = document.createElement('div');
+  element.className = 'cycletest';
+  if (id) {
+    element.id = id;
+  }
+  document.body.appendChild(element);
+  return element;
+}
+
+describe('makeDOMDriver', function () {
+  it('should accept a DOM element as input', function () {
+    const element = createRenderTarget();
+    assert.doesNotThrow(function () {
+      makeDOMDriver(element);
+    });
+  });
+
+  it('should accept a DocumentFragment as input', function () {
+    const element = document.createDocumentFragment();
+    assert.doesNotThrow(function () {
+      makeDOMDriver(element);
+    });
+  });
+
+  it('should accept a string selector to an existing element as input', function () {
+    const id = 'testShouldAcceptSelectorToExisting';
+    const element = createRenderTarget();
+    element.id = id;
+    assert.doesNotThrow(function () {
+      makeDOMDriver('#' + id);
+    });
+  });
+
+  it('should not accept a selector to an unknown element as input', function () {
+    assert.throws(function () {
+      makeDOMDriver('#nonsenseIdToNothing');
+    }, /Cannot render into unknown element/);
+  });
+
+  it('should not accept a number as input', function () {
+    assert.throws(function () {
+      makeDOMDriver(123);
+    }, /Given container is not a DOM element neither a selector string/);
+  });
+
+  it('should accept function as error callback', function () {
+    const element = document.createDocumentFragment();
+    const onError = function() {};
+    assert.doesNotThrow(function () {
+      makeDOMDriver(element, {onError});
+    });
+  });
+
+  it('should not accept number as error callback', function () {
+    const element = document.createDocumentFragment();
+    assert.throws(function () {
+      makeDOMDriver(element, {onError: 42});
+    });
+  });
+
+  it('should have a streamAdapter property', function () {
+    const element = createRenderTarget();
+    const DOMDriver = makeDOMDriver(element);
+    assert.notStrictEqual(typeof DOMDriver.streamAdapter, 'undefined');
+    assert.strictEqual(typeof DOMDriver.streamAdapter.adapt, 'function');
+    assert.strictEqual(typeof DOMDriver.streamAdapter.dispose, 'function');
+    assert.strictEqual(typeof DOMDriver.streamAdapter.makeHoldSubject, 'function');
+    assert.strictEqual(typeof DOMDriver.streamAdapter.isValidStream, 'function');
+    assert.strictEqual(typeof DOMDriver.streamAdapter.streamSubscribe, 'function');
+  });
+});
+
+describe('DOM Driver', function () {
+  it('should throw if input is not an Observable<VTree>', function () {
+    const domDriver = makeDOMDriver(createRenderTarget());
+    assert.throws(function () {
+      domDriver({});
+    }, /The DOM driver function expects as input an Observable of virtual/);
+  });
+
+  it('should pass errors to error callback', function (done) {
+    const error = new Error();
+    const errorCallback = function(e) {
+      assert.strictEqual(e, error);
+      done();
+    };
+
+    function app() {
+      return {
+        DOM: Rx.Observable.throw(error)
+      };
+    }
+
+    const {sinks, sources, run} = Cycle(app, {
+      DOM: makeDOMDriver(createRenderTarget(), {onError: errorCallback})
+    });
+    run();
+  });
+
+  it('should have isolateSource() and isolateSink() in source', function (done) {
+    function app() {
+      return {
+        DOM: Rx.Observable.of(div())
+      };
+    }
+
+    const {sinks, sources, run} = Cycle(app, {
+      DOM: makeDOMDriver(createRenderTarget())
+    });
+    let dispose = run();
+    assert.strictEqual(typeof sources.DOM.isolateSource, 'function');
+    assert.strictEqual(typeof sources.DOM.isolateSink, 'function');
+    dispose();
+    done();
+  });
+
+  it('should not work after has been disposed', function (done) {
+    const number$ = Rx.Observable.range(1, 3)
+      .concatMap(x => Rx.Observable.of(x).delay(50));
+
+    function app() {
+      return {
+        DOM: number$.map(number =>
+            h3('.target', String(number))
+        )
+      };
+    }
+
+    const {sinks, sources, run} = Cycle(app, {
+      DOM: makeDOMDriver(createRenderTarget())
+    });
+
+    let dispose;
+    sources.DOM.select(':root').element$.skip(1).subscribe(function (root) {
+      const selectEl = root.querySelector('.target');
+      assert.notStrictEqual(selectEl, null);
+      assert.notStrictEqual(typeof selectEl, 'undefined');
+      assert.strictEqual(selectEl.tagName, 'H3');
+      assert.notStrictEqual(selectEl.textContent, '3');
+      if (selectEl.textContent === '2') {
+        dispose();
+        setTimeout(() => {
+          done();
+        }, 100);
+      }
+    });
+    dispose = run();
+  });
+});

--- a/test/browser/rx/events.js
+++ b/test/browser/rx/events.js
@@ -1,8 +1,8 @@
 'use strict';
 /* global describe, it, beforeEach */
 let assert = require('assert');
-let Cycle = require('@cycle/core');
-let CycleDOM = require('../../lib/index');
+let Cycle = require('@cycle/rx-run').default;
+let CycleDOM = require('../../../lib/index');
 let Rx = require('rx');
 let {svg, div, input, p, span, h2, h3, h4, form, select, option, makeDOMDriver} = CycleDOM;
 
@@ -20,129 +20,137 @@ describe('DOMSource.events()', function () {
   it('should catch a basic click interaction Observable', function (done) {
     function app() {
       return {
-        DOM: Rx.Observable.just(h3('.myelementclass', 'Foobar'))
+        DOM: Rx.Observable.of(h3('.myelementclass', 'Foobar'))
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
-
+    let dispose;
     sources.DOM.select('.myelementclass').events('click').subscribe(ev => {
       assert.strictEqual(ev.type, 'click');
       assert.strictEqual(ev.target.textContent, 'Foobar');
-      sources.dispose();
+      console.log('dispose', dispose)
+      dispose();
       done();
     });
     // Make assertions
-    sources.DOM.select(':root').observable.skip(1).take(1).subscribe(function (root) {
+    sources.DOM.select(':root').element$.skip(1).take(1).subscribe(function (root) {
       const myElement = root.querySelector('.myelementclass');
       assert.notStrictEqual(myElement, null);
       assert.notStrictEqual(typeof myElement, 'undefined');
       assert.strictEqual(myElement.tagName, 'H3');
       assert.doesNotThrow(function () {
-        myElement.click();
+        setTimeout(() => myElement.click())
       });
     });
+    dispose = run();
   });
 
   it('should catch events using id of root element in DOM.select', function (done) {
     function app() {
       return {
-        DOM: Rx.Observable.just(h3('.myelementclass', 'Foobar'))
+        DOM: Rx.Observable.of(h3('.myelementclass', 'Foobar'))
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget('parent-001'))
     });
 
+    let dispose;
     // Make assertions
     sources.DOM.select('#parent-001').events('click').subscribe(ev => {
       assert.strictEqual(ev.type, 'click');
       assert.strictEqual(ev.target.textContent, 'Foobar');
-      sources.dispose();
+      dispose();
       done();
     });
 
-    sources.DOM.select(':root').observable.skip(1).take(1).subscribe(function (root) {
+    sources.DOM.select(':root').element$.skip(1).take(1).subscribe(function (root) {
       const myElement = root.querySelector('.myelementclass');
       assert.notStrictEqual(myElement, null);
       assert.notStrictEqual(typeof myElement, 'undefined');
       assert.strictEqual(myElement.tagName, 'H3');
       assert.doesNotThrow(function () {
-        myElement.click();
+        setTimeout(() => myElement.click());
       });
     });
+    dispose = run();
   });
 
   it('should catch events using id of top element in DOM.select', function (done) {
     function app() {
       return {
-        DOM: Rx.Observable.just(h3('#myElementId', 'Foobar'))
+        DOM: Rx.Observable.of(h3('#myElementId', 'Foobar'))
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget('parent-002'))
     });
 
+    let dispose;
     // Make assertions
     sources.DOM.select('#myElementId').events('click').subscribe(ev => {
       assert.strictEqual(ev.type, 'click');
       assert.strictEqual(ev.target.textContent, 'Foobar');
-      sources.dispose();
+      dispose();
       done();
     });
 
-    sources.DOM.select(':root').observable.skip(1).take(1)
+    sources.DOM.select(':root').element$.skip(1).take(1)
       .subscribe(function (root) {
         const myElement = root.querySelector('#myElementId');
         assert.notStrictEqual(myElement, null);
         assert.notStrictEqual(typeof myElement, 'undefined');
         assert.strictEqual(myElement.tagName, 'H3');
         assert.doesNotThrow(function () {
-          myElement.click();
+          setTimeout(() => myElement.click());
         });
       });
+    dispose = run();
   });
 
   it('should catch interaction events without prior select()', function (done) {
     function app() {
       return {
-        DOM: Rx.Observable.just(div('.parent', [
+        DOM: Rx.Observable.of(div('.parent', [
           h3('.myelementclass', 'Foobar')
         ]))
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
 
+    let dispose;
     // Make assertions
     sources.DOM.events('click').subscribe(ev => {
       assert.strictEqual(ev.type, 'click');
       assert.strictEqual(ev.target.textContent, 'Foobar');
-      sources.dispose();
+      dispose();
       done();
     });
 
-    sources.DOM.select(':root').observable.skip(1).take(1).subscribe(function (root) {
+    sources.DOM.select(':root').element$.skip(1).take(1).subscribe(function (root) {
       const myElement = root.querySelector('.myelementclass');
       assert.notStrictEqual(myElement, null);
       assert.notStrictEqual(typeof myElement, 'undefined');
       assert.strictEqual(myElement.tagName, 'H3');
       assert.doesNotThrow(function () {
-        myElement.click();
+        setTimeout(() => myElement.click());
       });
     });
+    dispose = run();
   });
 
   it('should catch user events using DOM.select().select().events()', function (done) {
     function app() {
       return {
-        DOM: Rx.Observable.just(
+        DOM: Rx.Observable.of(
           h3('.top-most', [
             h2('.bar', 'Wrong'),
             div('.foo', [
@@ -153,19 +161,20 @@ describe('DOMSource.events()', function () {
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
 
+    let dispose;
     // Make assertions
     sources.DOM.select('.foo').select('.bar').events('click').subscribe(ev => {
       assert.strictEqual(ev.type, 'click');
       assert.strictEqual(ev.target.textContent, 'Correct');
-      sources.dispose();
+      dispose();
       done();
     });
 
-    sources.DOM.select(':root').observable.skip(1).take(1)
+    sources.DOM.select(':root').element$.skip(1).take(1)
       .subscribe(function (root) {
         const wrongElement = root.querySelector('.bar');
         const correctElement = root.querySelector('.foo .bar');
@@ -176,42 +185,44 @@ describe('DOMSource.events()', function () {
         assert.strictEqual(wrongElement.tagName, 'H2');
         assert.strictEqual(correctElement.tagName, 'H4');
         assert.doesNotThrow(function () {
-          wrongElement.click();
-          setTimeout(() => correctElement.click(), 5);
+          setTimeout(() => wrongElement.click());
+          setTimeout(() => correctElement.click(), 15);
         });
       });
+    dispose = run();
   });
 
   it('should catch events from many elements using DOM.select().events()', function (done) {
     function app() {
       return {
-        DOM: Rx.Observable.just(div('.parent', [
+        DOM: Rx.Observable.of(div('.parent', [
           h4('.clickable.first', 'First'),
           h4('.clickable.second', 'Second'),
         ]))
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
 
+    let dispose;
     // Make assertions
-    sources.DOM.select('.clickable').events('click').elementAt(0)
+    sources.DOM.select('.clickable').events('click').take(1)
       .subscribe(ev => {
         assert.strictEqual(ev.type, 'click');
         assert.strictEqual(ev.target.textContent, 'First');
       });
 
-    sources.DOM.select('.clickable').events('click').elementAt(1)
+    sources.DOM.select('.clickable').events('click').skip(1).take(1)
       .subscribe(ev => {
         assert.strictEqual(ev.type, 'click');
         assert.strictEqual(ev.target.textContent, 'Second');
-        sources.dispose();
+        dispose();
         done();
       });
 
-    sources.DOM.select(':root').observable.skip(1).take(1)
+    sources.DOM.select(':root').element$.skip(1).take(1)
       .subscribe(function (root) {
         const firstElem = root.querySelector('.first');
         const secondElem = root.querySelector('.second');
@@ -220,36 +231,38 @@ describe('DOMSource.events()', function () {
         assert.notStrictEqual(secondElem, null);
         assert.notStrictEqual(typeof secondElem, 'undefined');
         assert.doesNotThrow(function () {
-          firstElem.click();
-          setTimeout(() => secondElem.click(), 1);
+          setTimeout(() => firstElem.click());
+          setTimeout(() => secondElem.click(), 5);
         });
       });
+    dispose = run();
   });
 
   it('should catch interaction events from future elements', function (done) {
     function app() {
       return {
         DOM: Rx.Observable.concat(
-          Rx.Observable.just(h2('.blesh', 'Blesh')),
-          Rx.Observable.just(h3('.blish', 'Blish')).delay(100),
-          Rx.Observable.just(h4('.blosh', 'Blosh')).delay(100)
+          Rx.Observable.of(h2('.blesh', 'Blesh')),
+          Rx.Observable.of(h3('.blish', 'Blish')).delay(100),
+          Rx.Observable.of(h4('.blosh', 'Blosh')).delay(100)
         )
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget('parent-002'))
     });
 
+    let dispose;
     // Make assertions
     sources.DOM.select('.blosh').events('click').subscribe(ev => {
       assert.strictEqual(ev.type, 'click');
       assert.strictEqual(ev.target.textContent, 'Blosh');
-      sources.dispose();
+      dispose();
       done();
     });
 
-    sources.DOM.select(':root').observable.skip(3).take(1)
+    sources.DOM.select(':root').element$.skip(3).take(1)
       .subscribe(function (root) {
         const myElement = root.querySelector('.blosh');
         assert.notStrictEqual(myElement, null);
@@ -257,15 +270,16 @@ describe('DOMSource.events()', function () {
         assert.strictEqual(myElement.tagName, 'H4');
         assert.strictEqual(myElement.textContent, 'Blosh');
         assert.doesNotThrow(function () {
-          myElement.click();
+          setTimeout(() => myElement.click());
         });
       });
+    dispose = run();
   });
 
   it('should have currentTarget or ownerTarget pointed to the selected parent', function (done) {
     function app() {
       return {
-        DOM: Rx.Observable.just(div('.top', [
+        DOM: Rx.Observable.of(div('.top', [
           h2('.parent', [
             span('.child', 'Hello world')
           ])
@@ -273,10 +287,11 @@ describe('DOMSource.events()', function () {
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
 
+    let dispose;
     sources.DOM.select('.parent').events('click').subscribe(ev => {
       assert.strictEqual(ev.type, 'click');
       assert.strictEqual(ev.target.tagName, 'SPAN');
@@ -287,26 +302,27 @@ describe('DOMSource.events()', function () {
       const ownerTargetIsParentH2 =
         ev.ownerTarget.tagName === 'H2' && ev.ownerTarget.className === 'parent';
       assert.strictEqual(currentTargetIsParentH2 || ownerTargetIsParentH2, true);
-      sources.dispose();
+      dispose();
       done();
     });
     // Make assertions
-    sources.DOM.select(':root').observable.skip(1).take(1).subscribe(function (root) {
+    sources.DOM.select(':root').element$.skip(1).take(1).subscribe(function (root) {
       const child = root.querySelector('.child');
       assert.notStrictEqual(child, null);
       assert.notStrictEqual(typeof child, 'undefined');
       assert.strictEqual(child.tagName, 'SPAN');
       assert.strictEqual(child.className, 'child');
       assert.doesNotThrow(function () {
-        child.click();
+        setTimeout(() => child.click());
       });
     });
+    dispose = run();
   });
 
   it('should catch a non-bubbling Form `reset` event', function (done) {
     function app() {
       return {
-        DOM: Rx.Observable.just(div('.parent', [
+        DOM: Rx.Observable.of(div('.parent', [
           form('.form', [
             input('.field', {type: 'text'})
           ])
@@ -314,7 +330,7 @@ describe('DOMSource.events()', function () {
       }
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
 
@@ -325,16 +341,17 @@ describe('DOMSource.events()', function () {
       done();
     });
 
-    sources.DOM.select(':root').observable.skip(1).take(1).subscribe(root => {
+    sources.DOM.select(':root').element$.skip(1).take(1).subscribe(root => {
       const form = root.querySelector('.form');
-      form.reset();
+      setTimeout(() => form.reset());
     });
+    run()
   });
 
   it('should catch a non-bubbling click event with useCapture', function (done) {
     function app() {
       return {
-        DOM: Rx.Observable.just(div('.parent', [
+        DOM: Rx.Observable.of(div('.parent', [
           div('.clickable', 'Hello')
         ]))
       }
@@ -353,7 +370,7 @@ describe('DOMSource.events()', function () {
       el.dispatchEvent(ev)
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
 
@@ -369,10 +386,11 @@ describe('DOMSource.events()', function () {
     sources.DOM.select('.clickable').events('click', {useCapture: false})
       .subscribe(assert.fail);
 
-    sources.DOM.select(':root').observable.skip(1).take(1).subscribe(root => {
+    sources.DOM.select(':root').element$.skip(1).take(1).subscribe(root => {
       const clickable = root.querySelector('.clickable');
-      click(clickable);
+      setTimeout(() => click(clickable));
     });
+    run();
   });
 
   // This test does not work if and only if the browser is unfocused in the
@@ -382,7 +400,7 @@ describe('DOMSource.events()', function () {
   it.skip('should catch a blur event with useCapture', function (done) {
     function app() {
       return {
-        DOM: Rx.Observable.just(div('.parent', [
+        DOM: Rx.Observable.of(div('.parent', [
           input('.correct', {type: 'text'}, []),
           input('.wrong', {type: 'text'}, []),
           input('.dummy', {type: 'text'})
@@ -390,7 +408,7 @@ describe('DOMSource.events()', function () {
       }
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
 
@@ -406,7 +424,7 @@ describe('DOMSource.events()', function () {
         done('should not capture blur events if useCapture is false')
       );
 
-    sources.DOM.select(':root').observable.skip(1).take(1).subscribe(root => {
+    sources.DOM.select(':root').element$.skip(1).take(1).subscribe(root => {
       const correct = root.querySelector('.correct');
       const wrong = root.querySelector('.wrong');
       const dummy = root.querySelector('.dummy');
@@ -415,6 +433,7 @@ describe('DOMSource.events()', function () {
       setTimeout(() => correct.focus(), 150);
       setTimeout(() => dummy.focus(), 200);
     });
+    run()
   });
 
   // This test does not work if and only if the browser is unfocused in the
@@ -424,7 +443,7 @@ describe('DOMSource.events()', function () {
   it.skip('should catch a blur event by default (no options)', function (done) {
     function app() {
       return {
-        DOM: Rx.Observable.just(div('.parent', [
+        DOM: Rx.Observable.of(div('.parent', [
           input('.correct', {type: 'text'}, []),
           input('.wrong', {type: 'text'}, []),
           input('.dummy', {type: 'text'})
@@ -432,7 +451,7 @@ describe('DOMSource.events()', function () {
       }
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
 
@@ -448,7 +467,7 @@ describe('DOMSource.events()', function () {
         done('should not capture blur events if useCapture is false')
       );
 
-    sources.DOM.select(':root').observable.skip(1).take(1).subscribe(root => {
+    sources.DOM.select(':root').element$.skip(1).take(1).subscribe(root => {
       const correct = root.querySelector('.correct');
       const wrong = root.querySelector('.wrong');
       const dummy = root.querySelector('.dummy');
@@ -457,5 +476,6 @@ describe('DOMSource.events()', function () {
       setTimeout(() => correct.focus(), 150);
       setTimeout(() => dummy.focus(), 200);
     });
+    run();
   });
 });

--- a/test/browser/rx/fixtures/issue-89.js
+++ b/test/browser/rx/fixtures/issue-89.js
@@ -1,6 +1,6 @@
 'use strict';
 let Cycle = require('@cycle/rx-run');
-let CycleDOM = require('../../../lib/index');
+let CycleDOM = require('../../../../lib/index');
 let Rx = require('rx');
 let {h} = CycleDOM;
 

--- a/test/browser/rx/isolation.js
+++ b/test/browser/rx/isolation.js
@@ -1,0 +1,425 @@
+'use strict';
+/* global describe, it, beforeEach */
+let assert = require('assert');
+let Cycle = require('@cycle/rx-run').default;
+let CycleDOM = require('../../../lib/index');
+let Rx = require('rx');
+let {h, svg, div, p, span, h2, h3, h4, hJSX, select, option, makeDOMDriver} = CycleDOM;
+
+function createRenderTarget(id = null) {
+  let element = document.createElement('div');
+  element.className = 'cycletest';
+  if (id) {
+    element.id = id;
+  }
+  document.body.appendChild(element);
+  return element;
+}
+
+describe('isolateSource', function () {
+  it('should have the same effect as DOM.select()', function (done) {
+    function app() {
+      return {
+        DOM: Rx.Observable.of(
+          h3('.top-most', [
+            h2('.bar', 'Wrong'),
+            div('.cycle-scope-foo', [
+              h4('.bar', 'Correct')
+            ])
+          ])
+        )
+      };
+    }
+
+    const {sinks, sources, run} = Cycle(app, {
+      DOM: makeDOMDriver(createRenderTarget())
+    });
+
+    let dispose;
+    const isolatedDOMSource = sources.DOM.isolateSource(sources.DOM, 'foo');
+
+    // Make assertions
+    isolatedDOMSource.select('.bar').element$.skip(1).take(1).subscribe(elements => {
+      assert.strictEqual(elements.length, 1);
+      const correctElement = elements[0];
+      assert.notStrictEqual(correctElement, null);
+      assert.notStrictEqual(typeof correctElement, 'undefined');
+      assert.strictEqual(correctElement.tagName, 'H4');
+      assert.strictEqual(correctElement.textContent, 'Correct');
+      setTimeout(() => {
+        dispose();
+        done();
+      })
+    });
+    dispose = run();
+  });
+
+  it('should return source also with isolateSource and isolateSink', function (done) {
+    function app() {
+      return {
+        DOM: Rx.Observable.of(h('h3.top-most'))
+      };
+    }
+
+    const {sinks, sources, run} = Cycle(app, {
+      DOM: makeDOMDriver(createRenderTarget())
+    });
+    let dispose = run();
+    const isolatedDOMSource = sources.DOM.isolateSource(sources.DOM, 'top-most');
+    // Make assertions
+    assert.strictEqual(typeof isolatedDOMSource.isolateSource, 'function');
+    assert.strictEqual(typeof isolatedDOMSource.isolateSink, 'function');
+    dispose();
+    done();
+  });
+});
+
+describe('isolateSink', function () {
+  it('should add a className to the vtree sink', function (done) {
+    function app(sources) {
+      const vtree$ = Rx.Observable.of(h3('.top-most'));
+      return {
+        DOM: sources.DOM.isolateSink(vtree$, 'foo'),
+      };
+    }
+
+    const {sinks, sources, run} = Cycle(app, {
+      DOM: makeDOMDriver(createRenderTarget())
+    });
+
+    let dispose;
+    // Make assertions
+    sources.DOM.select(':root').element$.skip(1).take(1)
+      .subscribe(function (root) {
+        const element = root.querySelector('.top-most');
+        assert.notStrictEqual(element, null);
+        assert.notStrictEqual(typeof element, 'undefined');
+        assert.strictEqual(element.tagName, 'H3');
+        assert.strictEqual(element.className, 'top-most cycle-scope-foo');
+        setTimeout(() => {
+          dispose();
+          done();
+        })
+      });
+    dispose = run()
+  });
+
+  it('should add a className to a vtree sink that had no className', function (done) {
+    function app(sources) {
+      const vtree$ = Rx.Observable.of(h3());
+      return {
+        DOM: sources.DOM.isolateSink(vtree$, 'foo'),
+      };
+    }
+
+    const {sinks, sources, run} = Cycle(app, {
+      DOM: makeDOMDriver(createRenderTarget())
+    });
+
+    let dispose;
+    // Make assertions
+    sources.DOM.select(':root').element$.skip(1).take(1)
+      .subscribe(function (root) {
+        const element = root.querySelector('h3');
+        assert.notStrictEqual(element, null);
+        assert.notStrictEqual(typeof element, 'undefined');
+        assert.strictEqual(element.tagName, 'H3');
+        assert.strictEqual(element.className, 'cycle-scope-foo');
+        setTimeout(() => {
+          dispose();
+          done();
+        });
+      });
+    dispose = run();
+  });
+
+  it('should not redundantly repeat the scope className', function (done) {
+    function app(sources) {
+      const vtree1$ = Rx.Observable.of(span('.tab1', 'Hi'));
+      const vtree2$ = Rx.Observable.of(span('.tab2', 'Hello'));
+      const first$ = sources.DOM.isolateSink(vtree1$, '1');
+      const second$ = sources.DOM.isolateSink(vtree2$, '2');
+      const switched$ = Rx.Observable.concat(
+        Rx.Observable.of(1).delay(50),
+        Rx.Observable.of(2).delay(50),
+        Rx.Observable.of(1).delay(50),
+        Rx.Observable.of(2).delay(50),
+        Rx.Observable.of(1).delay(50),
+        Rx.Observable.of(2).delay(50)
+      ).flatMapLatest(i => i === 1 ? first$ : second$);
+      return {
+        DOM: switched$
+      };
+    }
+
+    const {sinks, sources, run} = Cycle(app, {
+      DOM: makeDOMDriver(createRenderTarget())
+    });
+
+    let dispose;
+    // Make assertions
+    sources.DOM.select(':root').element$.skip(5).take(1)
+      .subscribe(function (root) {
+        const element = root.querySelector('span');
+        assert.notStrictEqual(element, null);
+        assert.notStrictEqual(typeof element, 'undefined');
+        assert.strictEqual(element.tagName, 'SPAN');
+        assert.strictEqual(element.className, 'tab1 cycle-scope-1');
+        dispose();
+        done();
+      });
+    dispose = run();
+  });
+});
+
+describe('isolation', function () {
+  it('should prevent parent from DOM.selecting() inside the isolation', function (done) {
+    function app(sources) {
+      return {
+        DOM: Rx.Observable.of(
+          h3('.top-most', [
+            sources.DOM.isolateSink(Rx.Observable.of(
+              div('.foo', [
+                h4('.bar', 'Wrong')
+              ])
+            ), 'ISOLATION'),
+            h2('.bar', 'Correct'),
+          ])
+        )
+      };
+    }
+
+    const {sinks, sources, run} = Cycle(app, {
+      DOM: makeDOMDriver(createRenderTarget())
+    });
+
+    sources.DOM.select('.bar').element$.skip(1).take(1).subscribe(function (elements) {
+      assert.strictEqual(Array.isArray(elements), true);
+      assert.strictEqual(elements.length, 1);
+      const correctElement = elements[0];
+      assert.notStrictEqual(correctElement, null);
+      assert.notStrictEqual(typeof correctElement, 'undefined');
+      assert.strictEqual(correctElement.tagName, 'H2');
+      assert.strictEqual(correctElement.textContent, 'Correct');
+      done();
+    });
+    run()
+  });
+
+  it('should allow parent to DOM.select() in its own isolation island', function (done) {
+    function app(sources) {
+      const {isolateSource, isolateSink} = sources.DOM;
+      const islandElement$ = isolateSource(sources.DOM, 'island')
+        .select('.bar').element$;
+      const islandVTree$ = isolateSink(
+        Rx.Observable.of(div([h3('.bar', 'Correct')])), 'island'
+      );
+      return {
+        DOM: Rx.Observable.of(
+          h3('.top-most', [
+            sources.DOM.isolateSink(Rx.Observable.of(
+              div('.foo', [
+                islandVTree$,
+                h4('.bar', 'Wrong')
+              ])
+            ), 'ISOLATION'),
+          ])
+        ),
+        island: islandElement$
+      };
+    }
+
+    const {sinks, sources, run} = Cycle(app, {
+      DOM: makeDOMDriver(createRenderTarget(), {transposition: true})
+    });
+
+    sinks.island.skip(1).take(1).subscribe(function (elements) {
+      assert.strictEqual(Array.isArray(elements), true);
+      assert.strictEqual(elements.length, 1);
+      const correctElement = elements[0];
+      assert.notStrictEqual(correctElement, null);
+      assert.notStrictEqual(typeof correctElement, 'undefined');
+      assert.strictEqual(correctElement.tagName, 'H3');
+      assert.strictEqual(correctElement.textContent, 'Correct');
+      done();
+    });
+    run()
+  });
+
+  it('should isolate DOM.select between parent and (wrapper) child', function (done) {
+    function Frame(sources) {
+      const click$ = sources.DOM.select('.foo').events('click');
+      const vtree$ = Rx.Observable.of(
+        h4('.foo.frame', {style: {backgroundColor: 'lightblue'}}, [
+          sources.content$
+        ])
+      );
+      return {
+        DOM: vtree$,
+        click$
+      };
+    }
+
+    function Monalisa(sources) {
+      const {isolateSource, isolateSink} = sources.DOM;
+
+      const islandDOMSource = isolateSource(sources.DOM, 'island');
+      const click$ = islandDOMSource.select('.foo').events('click');
+      const islandDOMSink$ = isolateSink(
+        Rx.Observable.of(span('.foo.monalisa', 'Monalisa')),
+        'island'
+      );
+
+      const frameDOMSource = isolateSource(sources.DOM, 'myFrame');
+      const frame = Frame({ DOM: frameDOMSource, content$: islandDOMSink$ });
+      const outerVTree$ = isolateSink(frame.DOM, 'myFrame');
+
+      return {
+        DOM: outerVTree$,
+        frameClick: frame.click$,
+        monalisaClick: click$
+      };
+    }
+
+    const {sources, sinks, run} = Cycle(Monalisa, {
+      DOM: makeDOMDriver(createRenderTarget(), {transposition: true})
+    });
+    let dispose;
+
+    const frameClick$ = sinks.frameClick.map(ev => ({
+      type: ev.type,
+      tagName: ev.target.tagName
+    }));
+
+    const monalisaClick$ = sinks.monalisaClick.map(ev => ({
+      type: ev.type,
+      tagName: ev.target.tagName
+    }));
+
+    // Stop the propagtion of the first click
+    sinks.monalisaClick.first().subscribe(ev => ev.stopPropagation());
+
+    // The frame should be notified about 2 clicks:
+    //  1. the second click on monalisa (whose propagation has not stopped)
+    //  2. the only click on the frame itself
+    frameClick$.take(2).sequenceEqual(
+      Rx.Observable.fromArray([
+        {type: 'click', tagName: 'SPAN'},
+        {type: 'click', tagName: 'H4'},
+      ])
+    ).subscribe(isEqual => {
+      assert.strictEqual(isEqual, true);
+      dispose();
+      done();
+    });
+
+    // Monalisa should receive two clicks
+    monalisaClick$.take(2).sequenceEqual(
+      Rx.Observable.fromArray([
+        {type: 'click', tagName: 'SPAN'},
+        {type: 'click', tagName: 'SPAN'},
+      ])
+    ).subscribe(isEqual => {
+      assert.strictEqual(isEqual, true);
+    });
+
+    sources.DOM.select(':root').element$.skip(1).take(1).subscribe(root => {
+      const frameFoo = root.querySelector('.foo.frame');
+      const monalisaFoo = root.querySelector('.foo.monalisa');
+      assert.notStrictEqual(frameFoo, null);
+      assert.notStrictEqual(monalisaFoo, null);
+      assert.notStrictEqual(typeof frameFoo, 'undefined');
+      assert.notStrictEqual(typeof monalisaFoo, 'undefined');
+      assert.strictEqual(frameFoo.tagName, 'H4');
+      assert.strictEqual(monalisaFoo.tagName, 'SPAN');
+      assert.doesNotThrow(() => {
+        setTimeout(() => monalisaFoo.click());
+        setTimeout(() => monalisaFoo.click());
+        setTimeout(() => frameFoo.click(), 0);
+      });
+    });
+    dispose = run();
+  });
+
+  it('should allow a child component to DOM.select() its own root', function (done) {
+    function app(sources) {
+      return {
+        DOM: Rx.Observable.of(
+          h3('.top-most', [
+            sources.DOM.isolateSink(Rx.Observable.of(
+              span('.foo', [
+                h4('.bar', 'Wrong')
+              ])
+            ), 'ISOLATION')
+          ])
+        )
+      };
+    }
+
+    const {sinks, sources, run} = Cycle(app, {
+      DOM: makeDOMDriver(createRenderTarget(), {transposition: true})
+    });
+
+    const {isolateSource} = sources.DOM;
+
+    isolateSource(sources.DOM, 'ISOLATION')
+      .select('.foo').element$
+      .skip(1).take(1)
+      .subscribe(function (elements) {
+        assert.strictEqual(Array.isArray(elements), true);
+        assert.strictEqual(elements.length, 1);
+        const correctElement = elements[0];
+        assert.notStrictEqual(correctElement, null);
+        assert.notStrictEqual(typeof correctElement, 'undefined');
+        assert.strictEqual(correctElement.tagName, 'SPAN');
+        done();
+      });
+    run();
+  });
+
+  it('should allow DOM.selecting svg elements', function (done) {
+    function App(sources) {
+      const triangleElement$ = sources.DOM.select('.triangle').element$;
+
+      const svgTriangle = svg({width: 150, height: 150}, [
+        h('polygon', {
+          attrs: {
+            class: 'triangle',
+            points: '20 0 20 150 150 20'
+          }
+        }),
+      ]);
+
+      return {
+        DOM: Rx.Observable.of(svgTriangle),
+        triangleElement: triangleElement$
+      };
+    }
+
+    function IsolatedApp(sources) {
+      const {isolateSource, isolateSink} = sources.DOM
+      const isolatedDOMSource = isolateSource(sources.DOM, 'ISOLATION');
+      const app = App({DOM: isolatedDOMSource});
+      const isolateDOMSink = isolateSink(app.DOM, 'ISOLATION');
+      return {
+        DOM: isolateDOMSink,
+        triangleElement: app.triangleElement
+      };
+    }
+
+    const {sinks, sources, run} = Cycle(IsolatedApp, {
+      DOM: makeDOMDriver(createRenderTarget())
+    });
+
+    // Make assertions
+    const selection = sinks.triangleElement.skip(1).take(1).subscribe(elements => {
+      assert.strictEqual(elements.length, 1);
+      const triangleElement = elements[0];
+      assert.notStrictEqual(triangleElement, null);
+      assert.notStrictEqual(typeof triangleElement, 'undefined');
+      assert.strictEqual(triangleElement.tagName, 'polygon');
+      done();
+    });
+    run();
+  });
+});

--- a/test/browser/rx/render.js
+++ b/test/browser/rx/render.js
@@ -1,8 +1,8 @@
 'use strict';
 /* global describe, it, beforeEach */
 let assert = require('assert');
-let Cycle = require('@cycle/core');
-let CycleDOM = require('../../lib/index');
+let Cycle = require('@cycle/rx-run').default;
+let CycleDOM = require('../../../lib/index');
 let Rx = require('rx');
 let {html} = require('snabbdom-jsx');
 let {h, svg, div, input, p, span, h2, h3, h4, select, option, thunk, makeDOMDriver} = CycleDOM;
@@ -21,7 +21,7 @@ describe('DOM Rendering', function () {
   it('should convert a simple virtual-dom <select> to DOM element', function (done) {
     function app() {
       return {
-        DOM: Rx.Observable.just(select('.my-class', [
+        DOM: Rx.Observable.of(select('.my-class', [
           option({value: 'foo'}, 'Foo'),
           option({value: 'bar'}, 'Bar'),
           option({value: 'baz'}, 'Baz')
@@ -29,24 +29,28 @@ describe('DOM Rendering', function () {
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
 
-    sources.DOM.select(':root').observable.skip(1).take(1).subscribe(function (root) {
+    let dispose;
+    sources.DOM.select(':root').element$.skip(1).take(1).subscribe(function (root) {
       const selectEl = root.querySelector('.my-class');
       assert.notStrictEqual(selectEl, null);
       assert.notStrictEqual(typeof selectEl, 'undefined');
       assert.strictEqual(selectEl.tagName, 'SELECT');
-      sources.dispose();
-      done();
+      setTimeout(() => {
+        dispose();
+        done();
+      });
     });
+    dispose = run();
   });
 
   it('should convert a simple virtual-dom <select> (JSX) to DOM element', function (done) {
     function app() {
       return {
-        DOM: Rx.Observable.just(
+        DOM: Rx.Observable.of(
           <select className="my-class">
             <option value="foo">Foo</option>
             <option value="bar">Bar</option>
@@ -56,18 +60,22 @@ describe('DOM Rendering', function () {
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
 
-    sources.DOM.select(':root').observable.skip(1).take(1).subscribe(function (root) {
+    let dispose;
+    sources.DOM.select(':root').element$.skip(1).take(1).subscribe(function (root) {
       const selectEl = root.querySelector('.my-class');
       assert.notStrictEqual(selectEl, null);
       assert.notStrictEqual(typeof selectEl, 'undefined');
       assert.strictEqual(selectEl.tagName, 'SELECT');
-      sources.dispose();
-      done();
+      setTimeout(() => {
+        dispose();
+        done();
+      })
     });
+    dispose = run();
   });
 
   it('should allow snabbdom Thunks in the VTree', function (done) {
@@ -87,19 +95,21 @@ describe('DOM Rendering', function () {
     }
 
     // Run it
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
 
+    let dispose;
     // Assert it
-    sources.DOM.select(':root').observable.skip(1).take(1).subscribe(function (root) {
+    sources.DOM.select(':root').element$.skip(1).take(1).subscribe(function (root) {
       const selectEl = root.querySelector('h4');
       assert.notStrictEqual(selectEl, null);
       assert.notStrictEqual(typeof selectEl, 'undefined');
       assert.strictEqual(selectEl.tagName, 'H4');
       assert.strictEqual(selectEl.textContent, 'Constantly hello0');
-      sources.dispose();
+      dispose();
       done();
     });
+    dispose = run();
   });
 });

--- a/test/browser/rx/transposition.js
+++ b/test/browser/rx/transposition.js
@@ -1,0 +1,231 @@
+'use strict';
+/* global describe, it, beforeEach */
+let assert = require('assert');
+let Cycle = require('@cycle/rx-run').default;
+let CycleDOM = require('../../../lib/index');
+let Fixture89 = require('./fixtures/issue-89');
+let Rx = require('rx');
+let {html} = require('snabbdom-jsx');
+let {h, svg, div, input, p, span, h2, h3, h4, select, option, thunk, makeDOMDriver} = CycleDOM;
+
+function createRenderTarget(id = null) {
+  let element = document.createElement('div');
+  element.className = 'cycletest';
+  if (id) {
+    element.id = id;
+  }
+  document.body.appendChild(element);
+  return element;
+}
+
+describe('DOM rendering with transposition', function () {
+  it('should accept a view wrapping a VTree$ (#89)', function (done) {
+    function app() {
+      const number$ = Fixture89.makeModelNumber$();
+      return {
+        DOM: Fixture89.viewWithContainerFn(number$)
+      };
+    }
+
+    const {sinks, sources, run} = Cycle(app, {
+      DOM: makeDOMDriver(createRenderTarget(), {transposition: true})
+    });
+
+    let dispose;
+    sources.DOM.select('.myelementclass').element$.skip(1).first() // 1st
+      .subscribe(function (elements) {
+        const myelement = elements[0];
+        assert.notStrictEqual(myelement, null);
+        assert.strictEqual(myelement.tagName, 'H3');
+        assert.strictEqual(myelement.textContent, '123');
+      });
+    sources.DOM.select('.myelementclass').element$.skip(2).first() // 2nd
+      .subscribe(function (elements) {
+        const myelement = elements[0];
+        assert.notStrictEqual(myelement, null);
+        assert.strictEqual(myelement.tagName, 'H3');
+        assert.strictEqual(myelement.textContent, '456');
+        setTimeout(() => {
+          dispose();
+          done();
+        });
+      });
+    dispose = run();
+  });
+
+  it('should accept a view with VTree$ as the root of VTree', function (done) {
+    function app() {
+      const number$ = Fixture89.makeModelNumber$();
+      return {
+        DOM: Fixture89.viewWithoutContainerFn(number$)
+      };
+    }
+
+    const {sinks, sources, run} = Cycle(app, {
+      DOM: makeDOMDriver(createRenderTarget(), {transposition: true})
+    });
+
+    let dispose;
+    sources.DOM.select('.myelementclass').element$.skip(1).first() // 1st
+      .subscribe(function (elements) {
+        const myelement = elements[0];
+        assert.notStrictEqual(myelement, null);
+        assert.strictEqual(myelement.tagName, 'H3');
+        assert.strictEqual(myelement.textContent, '123');
+      });
+    sources.DOM.select('.myelementclass').element$.skip(2).first() // 1st
+      .subscribe(function (elements) {
+        const myelement = elements[0];
+        assert.notStrictEqual(myelement, null);
+        assert.strictEqual(myelement.tagName, 'H3');
+        assert.strictEqual(myelement.textContent, '456');
+        setTimeout(() => {
+          dispose();
+          done();
+        });
+      });
+    dispose = run();
+  });
+
+  it('should render a VTree with a child Observable<VTree>', function (done) {
+    function app() {
+      const child$ = Rx.Observable.of(
+        h4('.child', {}, 'I am a kid')
+      ).delay(80);
+      return {
+        DOM: Rx.Observable.of(div('.my-class', [
+          p({}, 'Ordinary paragraph'),
+          child$
+        ]))
+      };
+    }
+
+    const {sinks, sources, run} = Cycle(app, {
+      DOM: makeDOMDriver(createRenderTarget(), {transposition: true})
+    });
+
+    let dispose;
+    sources.DOM.select(':root').element$.skip(1).take(1).subscribe(function (root) {
+      const selectEl = root.querySelector('.child');
+      assert.notStrictEqual(selectEl, null);
+      assert.notStrictEqual(typeof selectEl, 'undefined');
+      assert.strictEqual(selectEl.tagName, 'H4');
+      assert.strictEqual(selectEl.textContent, 'I am a kid');
+      setTimeout(() => {
+        dispose();
+        done();
+      })
+    });
+    dispose = run()
+  });
+
+  it('should render a VTree with a grandchild Observable<VTree>', function (done) {
+    function app() {
+      const grandchild$ = Rx.Observable.of(
+          h4('.grandchild', {}, [
+            'I am a baby'
+          ])
+        ).delay(20);
+      const child$ = Rx.Observable.of(
+          h3('.child', {}, [
+            'I am a kid',
+            grandchild$
+          ])
+        ).delay(80);
+      return {
+        DOM: Rx.Observable.of(div('.my-class', [
+          p({}, 'Ordinary paragraph'),
+          child$
+        ]))
+      };
+    }
+
+    const {sinks, sources, run} = Cycle(app, {
+      DOM: makeDOMDriver(createRenderTarget(), {transposition: true})
+    });
+
+    let dispose;
+    sources.DOM.select(':root').element$.skip(1).take(1).subscribe(function (root) {
+      const selectEl = root.querySelector('.grandchild');
+      assert.notStrictEqual(selectEl, null);
+      assert.notStrictEqual(typeof selectEl, 'undefined');
+      assert.strictEqual(selectEl.tagName, 'H4');
+      assert.strictEqual(selectEl.textContent, 'I am a baby');
+      setTimeout(() => {
+        dispose();
+        done();
+      })
+    });
+    dispose = run()
+  });
+
+  it('should render a SVG VTree with a child Observable<VTree>', function (done) {
+    function app() {
+      const child$ = Rx.Observable.of(
+        h('g', {
+          attrs: {'class': 'child'}
+        })
+      ).delay(80);
+      return {
+        DOM: Rx.Observable.of(svg([
+          h('g'),
+          child$
+        ]))
+      };
+    }
+
+    const {sinks, sources, run} = Cycle(app, {
+      DOM: makeDOMDriver(createRenderTarget(), {transposition: true})
+    });
+
+    let dispose
+    sources.DOM.select(':root').element$.skip(1).take(1).subscribe(function (root) {
+      const selectEl = root.querySelector('.child');
+      assert.notStrictEqual(selectEl, null);
+      assert.notStrictEqual(typeof selectEl, 'undefined');
+      assert.strictEqual(selectEl.tagName, 'g');
+      setTimeout(() => {
+        dispose();
+        done();
+      });
+    });
+    dispose = run();
+  });
+
+  it('should only be concerned with values from the most recent nested Observable', function (done) {
+    function app() {
+      return {
+        DOM: Rx.Observable.of(
+          div([
+            Rx.Observable.of(1).concat(Rx.Observable.of(2).delay(5)).map(outer =>
+              Rx.Observable.of(1).concat(Rx.Observable.of(2).delay(10)).map(inner =>
+                div('.target', outer+'/'+inner)
+              )
+            )
+          ])
+        )
+      };
+    };
+
+    const {sinks, sources, run} = Cycle(app, {
+      DOM: makeDOMDriver(createRenderTarget(), {transposition: true})
+    });
+
+    let dispose;
+
+    const expected = Rx.Observable.from(['1/1','2/1','2/2'])
+
+    sources.DOM.select('.target').element$
+      .skip(1)
+      .map(els => els[0].innerHTML)
+      .sequenceEqual(expected)
+      .subscribe((areSame) => {
+        assert.strictEqual(areSame, true);
+        setTimeout(() => {
+          dispose();
+          done();
+        });
+      });
+    dispose = run();
+  });
+});

--- a/test/browser/rxjs/events.js
+++ b/test/browser/rxjs/events.js
@@ -1,0 +1,481 @@
+'use strict';
+/* global describe, it, beforeEach */
+let assert = require('assert');
+let Cycle = require('@cycle/rxjs-run').default;
+let CycleDOM = require('../../../lib/index');
+let Rx = require('rxjs');
+let {svg, div, input, p, span, h2, h3, h4, form, select, option, makeDOMDriver} = CycleDOM;
+
+function createRenderTarget(id = null) {
+  let element = document.createElement('div');
+  element.className = 'cycletest';
+  if (id) {
+    element.id = id;
+  }
+  document.body.appendChild(element);
+  return element;
+}
+
+describe('DOMSource.events()', function () {
+  it('should catch a basic click interaction Observable', function (done) {
+    function app() {
+      return {
+        DOM: Rx.Observable.of(h3('.myelementclass', 'Foobar'))
+      };
+    }
+
+    const {sinks, sources, run} = Cycle(app, {
+      DOM: makeDOMDriver(createRenderTarget())
+    });
+    let dispose;
+    sources.DOM.select('.myelementclass').events('click').subscribe(ev => {
+      assert.strictEqual(ev.type, 'click');
+      assert.strictEqual(ev.target.textContent, 'Foobar');
+      console.log('dispose', dispose)
+      dispose();
+      done();
+    });
+    // Make assertions
+    sources.DOM.select(':root').element$.skip(1).take(1).subscribe(function (root) {
+      const myElement = root.querySelector('.myelementclass');
+      assert.notStrictEqual(myElement, null);
+      assert.notStrictEqual(typeof myElement, 'undefined');
+      assert.strictEqual(myElement.tagName, 'H3');
+      assert.doesNotThrow(function () {
+        setTimeout(() => myElement.click())
+      });
+    });
+    dispose = run();
+  });
+
+  it('should catch events using id of root element in DOM.select', function (done) {
+    function app() {
+      return {
+        DOM: Rx.Observable.of(h3('.myelementclass', 'Foobar'))
+      };
+    }
+
+    const {sinks, sources, run} = Cycle(app, {
+      DOM: makeDOMDriver(createRenderTarget('parent-001'))
+    });
+
+    let dispose;
+    // Make assertions
+    sources.DOM.select('#parent-001').events('click').subscribe(ev => {
+      assert.strictEqual(ev.type, 'click');
+      assert.strictEqual(ev.target.textContent, 'Foobar');
+      dispose();
+      done();
+    });
+
+    sources.DOM.select(':root').element$.skip(1).take(1).subscribe(function (root) {
+      const myElement = root.querySelector('.myelementclass');
+      assert.notStrictEqual(myElement, null);
+      assert.notStrictEqual(typeof myElement, 'undefined');
+      assert.strictEqual(myElement.tagName, 'H3');
+      assert.doesNotThrow(function () {
+        setTimeout(() => myElement.click());
+      });
+    });
+    dispose = run();
+  });
+
+  it('should catch events using id of top element in DOM.select', function (done) {
+    function app() {
+      return {
+        DOM: Rx.Observable.of(h3('#myElementId', 'Foobar'))
+      };
+    }
+
+    const {sinks, sources, run} = Cycle(app, {
+      DOM: makeDOMDriver(createRenderTarget('parent-002'))
+    });
+
+    let dispose;
+    // Make assertions
+    sources.DOM.select('#myElementId').events('click').subscribe(ev => {
+      assert.strictEqual(ev.type, 'click');
+      assert.strictEqual(ev.target.textContent, 'Foobar');
+      dispose();
+      done();
+    });
+
+    sources.DOM.select(':root').element$.skip(1).take(1)
+      .subscribe(function (root) {
+        const myElement = root.querySelector('#myElementId');
+        assert.notStrictEqual(myElement, null);
+        assert.notStrictEqual(typeof myElement, 'undefined');
+        assert.strictEqual(myElement.tagName, 'H3');
+        assert.doesNotThrow(function () {
+          setTimeout(() => myElement.click());
+        });
+      });
+    dispose = run();
+  });
+
+  it('should catch interaction events without prior select()', function (done) {
+    function app() {
+      return {
+        DOM: Rx.Observable.of(div('.parent', [
+          h3('.myelementclass', 'Foobar')
+        ]))
+      };
+    }
+
+    const {sinks, sources, run} = Cycle(app, {
+      DOM: makeDOMDriver(createRenderTarget())
+    });
+
+    let dispose;
+    // Make assertions
+    sources.DOM.events('click').subscribe(ev => {
+      assert.strictEqual(ev.type, 'click');
+      assert.strictEqual(ev.target.textContent, 'Foobar');
+      dispose();
+      done();
+    });
+
+    sources.DOM.select(':root').element$.skip(1).take(1).subscribe(function (root) {
+      const myElement = root.querySelector('.myelementclass');
+      assert.notStrictEqual(myElement, null);
+      assert.notStrictEqual(typeof myElement, 'undefined');
+      assert.strictEqual(myElement.tagName, 'H3');
+      assert.doesNotThrow(function () {
+        setTimeout(() => myElement.click());
+      });
+    });
+    dispose = run();
+  });
+
+  it('should catch user events using DOM.select().select().events()', function (done) {
+    function app() {
+      return {
+        DOM: Rx.Observable.of(
+          h3('.top-most', [
+            h2('.bar', 'Wrong'),
+            div('.foo', [
+              h4('.bar', 'Correct')
+            ])
+          ])
+        )
+      };
+    }
+
+    const {sinks, sources, run} = Cycle(app, {
+      DOM: makeDOMDriver(createRenderTarget())
+    });
+
+    let dispose;
+    // Make assertions
+    sources.DOM.select('.foo').select('.bar').events('click').subscribe(ev => {
+      assert.strictEqual(ev.type, 'click');
+      assert.strictEqual(ev.target.textContent, 'Correct');
+      dispose();
+      done();
+    });
+
+    sources.DOM.select(':root').element$.skip(1).take(1)
+      .subscribe(function (root) {
+        const wrongElement = root.querySelector('.bar');
+        const correctElement = root.querySelector('.foo .bar');
+        assert.notStrictEqual(wrongElement, null);
+        assert.notStrictEqual(correctElement, null);
+        assert.notStrictEqual(typeof wrongElement, 'undefined');
+        assert.notStrictEqual(typeof correctElement, 'undefined');
+        assert.strictEqual(wrongElement.tagName, 'H2');
+        assert.strictEqual(correctElement.tagName, 'H4');
+        assert.doesNotThrow(function () {
+          setTimeout(() => wrongElement.click());
+          setTimeout(() => correctElement.click(), 15);
+        });
+      });
+    dispose = run();
+  });
+
+  it('should catch events from many elements using DOM.select().events()', function (done) {
+    function app() {
+      return {
+        DOM: Rx.Observable.of(div('.parent', [
+          h4('.clickable.first', 'First'),
+          h4('.clickable.second', 'Second'),
+        ]))
+      };
+    }
+
+    const {sinks, sources, run} = Cycle(app, {
+      DOM: makeDOMDriver(createRenderTarget())
+    });
+
+    let dispose;
+    // Make assertions
+    sources.DOM.select('.clickable').events('click').take(1)
+      .subscribe(ev => {
+        assert.strictEqual(ev.type, 'click');
+        assert.strictEqual(ev.target.textContent, 'First');
+      });
+
+    sources.DOM.select('.clickable').events('click').skip(1).take(1)
+      .subscribe(ev => {
+        assert.strictEqual(ev.type, 'click');
+        assert.strictEqual(ev.target.textContent, 'Second');
+        dispose();
+        done();
+      });
+
+    sources.DOM.select(':root').element$.skip(1).take(1)
+      .subscribe(function (root) {
+        const firstElem = root.querySelector('.first');
+        const secondElem = root.querySelector('.second');
+        assert.notStrictEqual(firstElem, null);
+        assert.notStrictEqual(typeof firstElem, 'undefined');
+        assert.notStrictEqual(secondElem, null);
+        assert.notStrictEqual(typeof secondElem, 'undefined');
+        assert.doesNotThrow(function () {
+          setTimeout(() => firstElem.click());
+          setTimeout(() => secondElem.click(), 5);
+        });
+      });
+    dispose = run();
+  });
+
+  it('should catch interaction events from future elements', function (done) {
+    function app() {
+      return {
+        DOM: Rx.Observable.concat(
+          Rx.Observable.of(h2('.blesh', 'Blesh')),
+          Rx.Observable.of(h3('.blish', 'Blish')).delay(100),
+          Rx.Observable.of(h4('.blosh', 'Blosh')).delay(100)
+        )
+      };
+    }
+
+    const {sinks, sources, run} = Cycle(app, {
+      DOM: makeDOMDriver(createRenderTarget('parent-002'))
+    });
+
+    let dispose;
+    // Make assertions
+    sources.DOM.select('.blosh').events('click').subscribe(ev => {
+      assert.strictEqual(ev.type, 'click');
+      assert.strictEqual(ev.target.textContent, 'Blosh');
+      dispose();
+      done();
+    });
+
+    sources.DOM.select(':root').element$.skip(3).take(1)
+      .subscribe(function (root) {
+        const myElement = root.querySelector('.blosh');
+        assert.notStrictEqual(myElement, null);
+        assert.notStrictEqual(typeof myElement, 'undefined');
+        assert.strictEqual(myElement.tagName, 'H4');
+        assert.strictEqual(myElement.textContent, 'Blosh');
+        assert.doesNotThrow(function () {
+          setTimeout(() => myElement.click());
+        });
+      });
+    dispose = run();
+  });
+
+  it('should have currentTarget or ownerTarget pointed to the selected parent', function (done) {
+    function app() {
+      return {
+        DOM: Rx.Observable.of(div('.top', [
+          h2('.parent', [
+            span('.child', 'Hello world')
+          ])
+        ]))
+      };
+    }
+
+    const {sinks, sources, run} = Cycle(app, {
+      DOM: makeDOMDriver(createRenderTarget())
+    });
+
+    let dispose;
+    sources.DOM.select('.parent').events('click').subscribe(ev => {
+      assert.strictEqual(ev.type, 'click');
+      assert.strictEqual(ev.target.tagName, 'SPAN');
+      assert.strictEqual(ev.target.className, 'child');
+      assert.strictEqual(ev.target.textContent, 'Hello world');
+      const currentTargetIsParentH2 =
+        ev.currentTarget.tagName === 'H2' && ev.currentTarget.className === 'parent';
+      const ownerTargetIsParentH2 =
+        ev.ownerTarget.tagName === 'H2' && ev.ownerTarget.className === 'parent';
+      assert.strictEqual(currentTargetIsParentH2 || ownerTargetIsParentH2, true);
+      dispose();
+      done();
+    });
+    // Make assertions
+    sources.DOM.select(':root').element$.skip(1).take(1).subscribe(function (root) {
+      const child = root.querySelector('.child');
+      assert.notStrictEqual(child, null);
+      assert.notStrictEqual(typeof child, 'undefined');
+      assert.strictEqual(child.tagName, 'SPAN');
+      assert.strictEqual(child.className, 'child');
+      assert.doesNotThrow(function () {
+        setTimeout(() => child.click());
+      });
+    });
+    dispose = run();
+  });
+
+  it('should catch a non-bubbling Form `reset` event', function (done) {
+    function app() {
+      return {
+        DOM: Rx.Observable.of(div('.parent', [
+          form('.form', [
+            input('.field', {type: 'text'})
+          ])
+        ]))
+      }
+    }
+
+    const {sinks, sources, run} = Cycle(app, {
+      DOM: makeDOMDriver(createRenderTarget())
+    });
+
+    sources.DOM.select('.parent').events('reset').subscribe(ev => {
+      assert.strictEqual(ev.type, 'reset');
+      assert.strictEqual(ev.target.tagName, 'FORM');
+      assert.strictEqual(ev.target.className, 'form');
+      done();
+    });
+
+    sources.DOM.select(':root').element$.skip(1).take(1).subscribe(root => {
+      const form = root.querySelector('.form');
+      setTimeout(() => form.reset());
+    });
+    run()
+  });
+
+  it('should catch a non-bubbling click event with useCapture', function (done) {
+    function app() {
+      return {
+        DOM: Rx.Observable.of(div('.parent', [
+          div('.clickable', 'Hello')
+        ]))
+      }
+    }
+
+    function click(el) {
+      const ev = document.createEvent(`MouseEvent`)
+      ev.initMouseEvent(
+        `click`,
+        false /* bubble */, true /* cancelable */,
+        window, null,
+        0, 0, 0, 0, /* coordinates */
+        false, false, false, false, /* modifier keys */
+        0 /*left*/, null
+      )
+      el.dispatchEvent(ev)
+    }
+
+    const {sinks, sources, run} = Cycle(app, {
+      DOM: makeDOMDriver(createRenderTarget())
+    });
+
+    sources.DOM.select('.clickable').events('click', {useCapture: true})
+      .subscribe(ev => {
+        assert.strictEqual(ev.type, 'click');
+        assert.strictEqual(ev.target.tagName, 'DIV');
+        assert.strictEqual(ev.target.className, 'clickable');
+        assert.strictEqual(ev.target.textContent, 'Hello');
+        done();
+      });
+
+    sources.DOM.select('.clickable').events('click', {useCapture: false})
+      .subscribe(assert.fail);
+
+    sources.DOM.select(':root').element$.skip(1).take(1).subscribe(root => {
+      const clickable = root.querySelector('.clickable');
+      setTimeout(() => click(clickable));
+    });
+    run();
+  });
+
+  // This test does not work if and only if the browser is unfocused in the
+  // operating system. In some browsers in SauceLabs, this test would always
+  // fail for that reason. Until we find how to force the browser to be
+  // focused, we can't run this test.
+  it.skip('should catch a blur event with useCapture', function (done) {
+    function app() {
+      return {
+        DOM: Rx.Observable.of(div('.parent', [
+          input('.correct', {type: 'text'}, []),
+          input('.wrong', {type: 'text'}, []),
+          input('.dummy', {type: 'text'})
+        ]))
+      }
+    }
+
+    const {sinks, sources, run} = Cycle(app, {
+      DOM: makeDOMDriver(createRenderTarget())
+    });
+
+    sources.DOM.select('.correct').events('blur', {useCapture: true})
+      .subscribe(ev => {
+        assert.strictEqual(ev.type, 'blur');
+        assert.strictEqual(ev.target.className, 'correct');
+        done();
+      });
+
+    sources.DOM.select('.wrong').events('blur', {useCapture: false})
+      .subscribe(() =>
+        done('should not capture blur events if useCapture is false')
+      );
+
+    sources.DOM.select(':root').element$.skip(1).take(1).subscribe(root => {
+      const correct = root.querySelector('.correct');
+      const wrong = root.querySelector('.wrong');
+      const dummy = root.querySelector('.dummy');
+      setTimeout(() => wrong.focus(), 50);
+      setTimeout(() => dummy.focus(), 100);
+      setTimeout(() => correct.focus(), 150);
+      setTimeout(() => dummy.focus(), 200);
+    });
+    run()
+  });
+
+  // This test does not work if and only if the browser is unfocused in the
+  // operating system. In some browsers in SauceLabs, this test would always
+  // fail for that reason. Until we find how to force the browser to be
+  // focused, we can't run this test.
+  it.skip('should catch a blur event by default (no options)', function (done) {
+    function app() {
+      return {
+        DOM: Rx.Observable.of(div('.parent', [
+          input('.correct', {type: 'text'}, []),
+          input('.wrong', {type: 'text'}, []),
+          input('.dummy', {type: 'text'})
+        ]))
+      }
+    }
+
+    const {sinks, sources, run} = Cycle(app, {
+      DOM: makeDOMDriver(createRenderTarget())
+    });
+
+    sources.DOM.select('.correct').events('blur')
+      .subscribe(ev => {
+        assert.strictEqual(ev.type, 'blur');
+        assert.strictEqual(ev.target.className, 'correct');
+        done();
+      });
+
+    sources.DOM.select('.wrong').events('blur', {useCapture: false})
+      .subscribe(() =>
+        done('should not capture blur events if useCapture is false')
+      );
+
+    sources.DOM.select(':root').element$.skip(1).take(1).subscribe(root => {
+      const correct = root.querySelector('.correct');
+      const wrong = root.querySelector('.wrong');
+      const dummy = root.querySelector('.dummy');
+      setTimeout(() => wrong.focus(), 50);
+      setTimeout(() => dummy.focus(), 100);
+      setTimeout(() => correct.focus(), 150);
+      setTimeout(() => dummy.focus(), 200);
+    });
+    run();
+  });
+});

--- a/test/browser/rxjs/fixtures/issue-89.js
+++ b/test/browser/rxjs/fixtures/issue-89.js
@@ -1,7 +1,7 @@
 'use strict';
-let Cycle = require('@cycle/rx-run');
-let CycleDOM = require('../../../lib/index');
-let Rx = require('rx');
+let Cycle = require('@cycle/rxjs-run');
+let CycleDOM = require('../../../../lib/index');
+let Rx = require('rxjs');
 let {h} = CycleDOM;
 
 function myElement(content) {

--- a/test/browser/rxjs/isolation.js
+++ b/test/browser/rxjs/isolation.js
@@ -1,9 +1,9 @@
 'use strict';
 /* global describe, it, beforeEach */
 let assert = require('assert');
-let Cycle = require('@cycle/core');
-let CycleDOM = require('../../lib/index');
-let Rx = require('rx');
+let Cycle = require('@cycle/rxjs-run').default;
+let CycleDOM = require('../../../lib/index');
+let Rx = require('rxjs');
 let {h, svg, div, p, span, h2, h3, h4, hJSX, select, option, makeDOMDriver} = CycleDOM;
 
 function createRenderTarget(id = null) {
@@ -20,7 +20,7 @@ describe('isolateSource', function () {
   it('should have the same effect as DOM.select()', function (done) {
     function app() {
       return {
-        DOM: Rx.Observable.just(
+        DOM: Rx.Observable.of(
           h3('.top-most', [
             h2('.bar', 'Wrong'),
             div('.cycle-scope-foo', [
@@ -31,40 +31,45 @@ describe('isolateSource', function () {
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
+
+    let dispose;
     const isolatedDOMSource = sources.DOM.isolateSource(sources.DOM, 'foo');
 
     // Make assertions
-    isolatedDOMSource.select('.bar').observable.skip(1).take(1).subscribe(elements => {
+    isolatedDOMSource.select('.bar').element$.skip(1).take(1).subscribe(elements => {
       assert.strictEqual(elements.length, 1);
       const correctElement = elements[0];
       assert.notStrictEqual(correctElement, null);
       assert.notStrictEqual(typeof correctElement, 'undefined');
       assert.strictEqual(correctElement.tagName, 'H4');
       assert.strictEqual(correctElement.textContent, 'Correct');
-      sources.dispose();
-      done();
+      setTimeout(() => {
+        dispose();
+        done();
+      })
     });
+    dispose = run();
   });
 
   it('should return source also with isolateSource and isolateSink', function (done) {
     function app() {
       return {
-        DOM: Rx.Observable.just(h('h3.top-most'))
+        DOM: Rx.Observable.of(h('h3.top-most'))
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
-
+    let dispose = run();
     const isolatedDOMSource = sources.DOM.isolateSource(sources.DOM, 'top-most');
     // Make assertions
     assert.strictEqual(typeof isolatedDOMSource.isolateSource, 'function');
     assert.strictEqual(typeof isolatedDOMSource.isolateSink, 'function');
-    sources.dispose();
+    dispose();
     done();
   });
 });
@@ -72,88 +77,98 @@ describe('isolateSource', function () {
 describe('isolateSink', function () {
   it('should add a className to the vtree sink', function (done) {
     function app(sources) {
-      const vtree$ = Rx.Observable.just(h3('.top-most'));
+      const vtree$ = Rx.Observable.of(h3('.top-most'));
       return {
         DOM: sources.DOM.isolateSink(vtree$, 'foo'),
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
 
+    let dispose;
     // Make assertions
-    sources.DOM.select(':root').observable.skip(1).take(1)
+    sources.DOM.select(':root').element$.skip(1).take(1)
       .subscribe(function (root) {
         const element = root.querySelector('.top-most');
         assert.notStrictEqual(element, null);
         assert.notStrictEqual(typeof element, 'undefined');
         assert.strictEqual(element.tagName, 'H3');
         assert.strictEqual(element.className, 'top-most cycle-scope-foo');
-        sources.dispose();
-        done();
+        setTimeout(() => {
+          dispose();
+          done();
+        })
       });
+    dispose = run()
   });
 
   it('should add a className to a vtree sink that had no className', function (done) {
     function app(sources) {
-      const vtree$ = Rx.Observable.just(h3());
+      const vtree$ = Rx.Observable.of(h3());
       return {
         DOM: sources.DOM.isolateSink(vtree$, 'foo'),
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
 
+    let dispose;
     // Make assertions
-    sources.DOM.select(':root').observable.skip(1).take(1)
+    sources.DOM.select(':root').element$.skip(1).take(1)
       .subscribe(function (root) {
         const element = root.querySelector('h3');
         assert.notStrictEqual(element, null);
         assert.notStrictEqual(typeof element, 'undefined');
         assert.strictEqual(element.tagName, 'H3');
         assert.strictEqual(element.className, 'cycle-scope-foo');
-        sources.dispose();
-        done();
+        setTimeout(() => {
+          dispose();
+          done();
+        });
       });
+    dispose = run();
   });
 
   it('should not redundantly repeat the scope className', function (done) {
     function app(sources) {
-      const vtree1$ = Rx.Observable.just(span('.tab1', 'Hi'));
-      const vtree2$ = Rx.Observable.just(span('.tab2', 'Hello'));
+      const vtree1$ = Rx.Observable.of(span('.tab1', 'Hi'));
+      const vtree2$ = Rx.Observable.of(span('.tab2', 'Hello'));
       const first$ = sources.DOM.isolateSink(vtree1$, '1');
       const second$ = sources.DOM.isolateSink(vtree2$, '2');
       const switched$ = Rx.Observable.concat(
-        Rx.Observable.just(1).delay(50),
-        Rx.Observable.just(2).delay(50),
-        Rx.Observable.just(1).delay(50),
-        Rx.Observable.just(2).delay(50),
-        Rx.Observable.just(1).delay(50),
-        Rx.Observable.just(2).delay(50)
-      ).flatMapLatest(i => i === 1 ? first$ : second$);
+        Rx.Observable.of(1).delay(50),
+        Rx.Observable.of(2).delay(50),
+        Rx.Observable.of(1).delay(50),
+        Rx.Observable.of(2).delay(50),
+        Rx.Observable.of(1).delay(50),
+        Rx.Observable.of(2).delay(50)
+      ).switchMap(i => i === 1 ? first$ : second$);
       return {
         DOM: switched$
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
 
+    let dispose;
     // Make assertions
-    sources.DOM.select(':root').observable.skip(5).take(1)
+    sources.DOM.select(':root').element$.skip(5).take(1)
       .subscribe(function (root) {
         const element = root.querySelector('span');
         assert.notStrictEqual(element, null);
         assert.notStrictEqual(typeof element, 'undefined');
         assert.strictEqual(element.tagName, 'SPAN');
         assert.strictEqual(element.className, 'tab1 cycle-scope-1');
-        sources.dispose();
+        dispose();
         done();
       });
+    dispose = run();
   });
 });
 
@@ -161,9 +176,9 @@ describe('isolation', function () {
   it('should prevent parent from DOM.selecting() inside the isolation', function (done) {
     function app(sources) {
       return {
-        DOM: Rx.Observable.just(
+        DOM: Rx.Observable.of(
           h3('.top-most', [
-            sources.DOM.isolateSink(Rx.Observable.just(
+            sources.DOM.isolateSink(Rx.Observable.of(
               div('.foo', [
                 h4('.bar', 'Wrong')
               ])
@@ -174,11 +189,11 @@ describe('isolation', function () {
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
 
-    sources.DOM.select('.bar').observable.skip(1).take(1).subscribe(function (elements) {
+    sources.DOM.select('.bar').element$.skip(1).take(1).subscribe(function (elements) {
       assert.strictEqual(Array.isArray(elements), true);
       assert.strictEqual(elements.length, 1);
       const correctElement = elements[0];
@@ -188,20 +203,21 @@ describe('isolation', function () {
       assert.strictEqual(correctElement.textContent, 'Correct');
       done();
     });
+    run()
   });
 
   it('should allow parent to DOM.select() in its own isolation island', function (done) {
     function app(sources) {
       const {isolateSource, isolateSink} = sources.DOM;
       const islandElement$ = isolateSource(sources.DOM, 'island')
-        .select('.bar').observable;
+        .select('.bar').element$;
       const islandVTree$ = isolateSink(
-        Rx.Observable.just(div([h3('.bar', 'Correct')])), 'island'
+        Rx.Observable.of(div([h3('.bar', 'Correct')])), 'island'
       );
       return {
-        DOM: Rx.Observable.just(
+        DOM: Rx.Observable.of(
           h3('.top-most', [
-            sources.DOM.isolateSink(Rx.Observable.just(
+            sources.DOM.isolateSink(Rx.Observable.of(
               div('.foo', [
                 islandVTree$,
                 h4('.bar', 'Wrong')
@@ -213,7 +229,7 @@ describe('isolation', function () {
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget(), {transposition: true})
     });
 
@@ -227,12 +243,13 @@ describe('isolation', function () {
       assert.strictEqual(correctElement.textContent, 'Correct');
       done();
     });
+    run()
   });
 
   it('should isolate DOM.select between parent and (wrapper) child', function (done) {
     function Frame(sources) {
       const click$ = sources.DOM.select('.foo').events('click');
-      const vtree$ = Rx.Observable.just(
+      const vtree$ = Rx.Observable.of(
         h4('.foo.frame', {style: {backgroundColor: 'lightblue'}}, [
           sources.content$
         ])
@@ -249,7 +266,7 @@ describe('isolation', function () {
       const islandDOMSource = isolateSource(sources.DOM, 'island');
       const click$ = islandDOMSource.select('.foo').events('click');
       const islandDOMSink$ = isolateSink(
-        Rx.Observable.just(span('.foo.monalisa', 'Monalisa')),
+        Rx.Observable.of(span('.foo.monalisa', 'Monalisa')),
         'island'
       );
 
@@ -264,9 +281,10 @@ describe('isolation', function () {
       };
     }
 
-    const {sources, sinks} = Cycle.run(Monalisa, {
+    const {sources, sinks, run} = Cycle(Monalisa, {
       DOM: makeDOMDriver(createRenderTarget(), {transposition: true})
     });
+    let dispose;
 
     const frameClick$ = sinks.frameClick.map(ev => ({
       type: ev.type,
@@ -284,28 +302,32 @@ describe('isolation', function () {
     // The frame should be notified about 2 clicks:
     //  1. the second click on monalisa (whose propagation has not stopped)
     //  2. the only click on the frame itself
-    frameClick$.take(2).sequenceEqual(
-      Rx.Observable.fromArray([
-        {type: 'click', tagName: 'SPAN'},
-        {type: 'click', tagName: 'H4'},
-      ])
-    ).subscribe(isEqual => {
-      assert.strictEqual(isEqual, true);
-      sources.dispose();
-      done();
+    const expected = [
+      {type: 'click', tagName: 'SPAN'},
+      {type: 'click', tagName: 'H4'},
+    ]
+    frameClick$.take(2).subscribe(event => {
+      let e = expected.shift()
+      assert.strictEqual(event.type, e.type)
+      assert.strictEqual(event.tagName, e.tagName);
+      if (expected.length === 0) {
+        dispose();
+        done();
+      }
     });
 
+    const otherExpected = [
+      {type: 'click', tagName: 'SPAN'},
+      {type: 'click', tagName: 'SPAN'},
+    ]
     // Monalisa should receive two clicks
-    monalisaClick$.take(2).sequenceEqual(
-      Rx.Observable.fromArray([
-        {type: 'click', tagName: 'SPAN'},
-        {type: 'click', tagName: 'SPAN'},
-      ])
-    ).subscribe(isEqual => {
-      assert.strictEqual(isEqual, true);
+    monalisaClick$.take(2).subscribe(event => {
+      let e = other.shift()
+      assert.strictEqual(event.type, e.type)
+      assert.strictEqual(event.tagName, e.tagName);
     });
 
-    sources.DOM.select(':root').observable.skip(1).take(1).subscribe(root => {
+    sources.DOM.select(':root').element$.skip(1).take(1).subscribe(root => {
       const frameFoo = root.querySelector('.foo.frame');
       const monalisaFoo = root.querySelector('.foo.monalisa');
       assert.notStrictEqual(frameFoo, null);
@@ -315,19 +337,20 @@ describe('isolation', function () {
       assert.strictEqual(frameFoo.tagName, 'H4');
       assert.strictEqual(monalisaFoo.tagName, 'SPAN');
       assert.doesNotThrow(() => {
-        monalisaFoo.click();
-        monalisaFoo.click();
+        setTimeout(() => monalisaFoo.click());
+        setTimeout(() => monalisaFoo.click());
         setTimeout(() => frameFoo.click(), 0);
       });
     });
+    dispose = run();
   });
 
   it('should allow a child component to DOM.select() its own root', function (done) {
     function app(sources) {
       return {
-        DOM: Rx.Observable.just(
+        DOM: Rx.Observable.of(
           h3('.top-most', [
-            sources.DOM.isolateSink(Rx.Observable.just(
+            sources.DOM.isolateSink(Rx.Observable.of(
               span('.foo', [
                 h4('.bar', 'Wrong')
               ])
@@ -337,14 +360,14 @@ describe('isolation', function () {
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget(), {transposition: true})
     });
 
     const {isolateSource} = sources.DOM;
 
     isolateSource(sources.DOM, 'ISOLATION')
-      .select('.foo').observable
+      .select('.foo').element$
       .skip(1).take(1)
       .subscribe(function (elements) {
         assert.strictEqual(Array.isArray(elements), true);
@@ -355,11 +378,12 @@ describe('isolation', function () {
         assert.strictEqual(correctElement.tagName, 'SPAN');
         done();
       });
+    run();
   });
 
   it('should allow DOM.selecting svg elements', function (done) {
     function App(sources) {
-      const triangleElement$ = sources.DOM.select('.triangle').observable;
+      const triangleElement$ = sources.DOM.select('.triangle').element$;
 
       const svgTriangle = svg({width: 150, height: 150}, [
         h('polygon', {
@@ -371,7 +395,7 @@ describe('isolation', function () {
       ]);
 
       return {
-        DOM: Rx.Observable.just(svgTriangle),
+        DOM: Rx.Observable.of(svgTriangle),
         triangleElement: triangleElement$
       };
     }
@@ -387,7 +411,7 @@ describe('isolation', function () {
       };
     }
 
-    const {sinks, sources} = Cycle.run(IsolatedApp, {
+    const {sinks, sources, run} = Cycle(IsolatedApp, {
       DOM: makeDOMDriver(createRenderTarget())
     });
 
@@ -400,5 +424,6 @@ describe('isolation', function () {
       assert.strictEqual(triangleElement.tagName, 'polygon');
       done();
     });
+    run();
   });
 });

--- a/test/browser/rxjs/render.js
+++ b/test/browser/rxjs/render.js
@@ -1,0 +1,115 @@
+'use strict';
+/* global describe, it, beforeEach */
+let assert = require('assert');
+let Cycle = require('@cycle/rxjs-run').default;
+let CycleDOM = require('../../../lib/index');
+let Rx = require('rxjs');
+let {html} = require('snabbdom-jsx');
+let {h, svg, div, input, p, span, h2, h3, h4, select, option, thunk, makeDOMDriver} = CycleDOM;
+
+function createRenderTarget(id = null) {
+  let element = document.createElement('div');
+  element.className = 'cycletest';
+  if (id) {
+    element.id = id;
+  }
+  document.body.appendChild(element);
+  return element;
+}
+
+describe('DOM Rendering', function () {
+  it('should convert a simple virtual-dom <select> to DOM element', function (done) {
+    function app() {
+      return {
+        DOM: Rx.Observable.of(select('.my-class', [
+          option({value: 'foo'}, 'Foo'),
+          option({value: 'bar'}, 'Bar'),
+          option({value: 'baz'}, 'Baz')
+        ]))
+      };
+    }
+
+    const {sinks, sources, run} = Cycle(app, {
+      DOM: makeDOMDriver(createRenderTarget())
+    });
+
+    let dispose;
+    sources.DOM.select(':root').element$.skip(1).take(1).subscribe(function (root) {
+      const selectEl = root.querySelector('.my-class');
+      assert.notStrictEqual(selectEl, null);
+      assert.notStrictEqual(typeof selectEl, 'undefined');
+      assert.strictEqual(selectEl.tagName, 'SELECT');
+      setTimeout(() => {
+        dispose();
+        done();
+      });
+    });
+    dispose = run();
+  });
+
+  it('should convert a simple virtual-dom <select> (JSX) to DOM element', function (done) {
+    function app() {
+      return {
+        DOM: Rx.Observable.of(
+          <select className="my-class">
+            <option value="foo">Foo</option>
+            <option value="bar">Bar</option>
+            <option value="baz">Baz</option>
+          </select>
+        )
+      };
+    }
+
+    const {sinks, sources, run} = Cycle(app, {
+      DOM: makeDOMDriver(createRenderTarget())
+    });
+
+    let dispose;
+    sources.DOM.select(':root').element$.skip(1).take(1).subscribe(function (root) {
+      const selectEl = root.querySelector('.my-class');
+      assert.notStrictEqual(selectEl, null);
+      assert.notStrictEqual(typeof selectEl, 'undefined');
+      assert.strictEqual(selectEl.tagName, 'SELECT');
+      setTimeout(() => {
+        dispose();
+        done();
+      })
+    });
+    dispose = run();
+  });
+
+  it('should allow snabbdom Thunks in the VTree', function (done) {
+    function renderThunk(greeting) {
+      return h4('Constantly ' + greeting)
+    }
+
+    // The Cycle.js app
+    function app() {
+      return {
+        DOM: Rx.Observable.interval(10).take(5).map(i =>
+          div([
+            thunk('thunk', renderThunk, 'hello' + 0)
+          ])
+        )
+      };
+    }
+
+    // Run it
+    const {sinks, sources, run} = Cycle(app, {
+      DOM: makeDOMDriver(createRenderTarget())
+    });
+
+    let dispose;
+    // Assert it
+    sources.DOM.select(':root').element$.skip(1).take(1).subscribe(function (root) {
+      const selectEl = root.querySelector('h4');
+      assert.notStrictEqual(selectEl, null);
+      assert.notStrictEqual(typeof selectEl, 'undefined');
+      assert.strictEqual(selectEl.tagName, 'H4');
+      assert.strictEqual(selectEl.textContent, 'Constantly hello0');
+      dispose();
+      done();
+    });
+    dispose = run();
+  });
+});

--- a/test/browser/rxjs/select.js
+++ b/test/browser/rxjs/select.js
@@ -1,0 +1,173 @@
+'use strict';
+/* global describe, it */
+let assert = require('assert');
+let Cycle = require('@cycle/rxjs-run').default;
+let CycleDOM = require('../../../lib/index');
+let Fixture89 = require('./fixtures/issue-89');
+let Rx = require('rxjs');
+let {h, svg, div, input, p, span, h2, h3, h4, select, option, makeDOMDriver} = CycleDOM;
+
+function createRenderTarget(id = null) {
+  let element = document.createElement('div');
+  element.className = 'cycletest';
+  if (id) {
+    element.id = id;
+  }
+  document.body.appendChild(element);
+  return element;
+}
+
+describe('DOMSource.select()', function () {
+  it('should have Observable `:root` in DOM source', function (done) {
+    function app() {
+      return {
+        DOM: Rx.Observable.of(
+          div('.top-most', [
+            p('Foo'),
+            span('Bar')
+          ])
+        )
+      };
+    }
+
+    const {sinks, sources, run} = Cycle(app, {
+      DOM: makeDOMDriver(createRenderTarget())
+    });
+
+    let dispose;
+    sources.DOM.select(':root').element$.skip(1).take(1).subscribe(root => {
+      const classNameRegex = /top\-most/;
+      assert.strictEqual(root.tagName, 'DIV');
+      const child = root.children[0];
+      assert.notStrictEqual(classNameRegex.exec(child.className), null);
+      assert.strictEqual(classNameRegex.exec(child.className)[0], 'top-most');
+      setTimeout(() => {
+        dispose();
+        done();
+      })
+    });
+    dispose = run();
+  });
+
+  it('should return an object with observable and events()', function (done) {
+    function app() {
+      return {
+        DOM: Rx.Observable.of(h3('.myelementclass', 'Foobar'))
+      };
+    }
+
+    const {sinks, sources, run} = Cycle(app, {
+      DOM: makeDOMDriver(createRenderTarget())
+    });
+
+    let dispose = run();
+    // Make assertions
+    const selection = sources.DOM.select('.myelementclass');
+    assert.strictEqual(typeof selection, 'object');
+    assert.strictEqual(typeof selection.element$, 'object');
+    assert.strictEqual(typeof selection.element$.subscribe, 'function');
+    assert.strictEqual(typeof selection.events, 'function');
+    dispose();
+    done();
+  });
+
+  it('should have an observable of DOM elements', function (done) {
+    function app() {
+      return {
+        DOM: Rx.Observable.of(h3('.myelementclass', 'Foobar'))
+      };
+    }
+
+    const {sinks, sources, run} = Cycle(app, {
+      DOM: makeDOMDriver(createRenderTarget())
+    });
+
+    let dispose;
+    // Make assertions
+    sources.DOM.select('.myelementclass').element$.skip(1).take(1)
+      .subscribe(elements => {
+        assert.notStrictEqual(elements, null);
+        assert.notStrictEqual(typeof elements, 'undefined');
+        // Is an Array
+        assert.strictEqual(Array.isArray(elements), true);
+        assert.strictEqual(elements.length, 1);
+        // Array with the H3 element
+        assert.strictEqual(elements[0].tagName, 'H3');
+        assert.strictEqual(elements[0].textContent, 'Foobar');
+        setTimeout(() => {
+          dispose();
+          done();
+        });
+      });
+    dispose = run();
+  });
+
+  it('should not select element outside the given scope', function (done) {
+    function app() {
+      return {
+        DOM: Rx.Observable.of(
+          h3('.top-most', [
+            h2('.bar', 'Wrong'),
+            div('.foo', [
+              h4('.bar', 'Correct')
+            ])
+          ])
+        )
+      };
+    }
+
+    const {sinks, sources, run} = Cycle(app, {
+      DOM: makeDOMDriver(createRenderTarget())
+    });
+
+    let dispose;
+    // Make assertions
+    sources.DOM.select('.foo').select('.bar').element$.skip(1).take(1)
+      .subscribe(elements => {
+        assert.strictEqual(elements.length, 1);
+        const element = elements[0];
+        assert.notStrictEqual(element, null);
+        assert.notStrictEqual(typeof element, 'undefined');
+        assert.strictEqual(element.tagName, 'H4');
+        assert.strictEqual(element.textContent, 'Correct');
+        setTimeout(() => {
+          dispose();
+          done();
+        });
+      })
+    dispose = run();
+  });
+
+  it('should select svg element', function (done) {
+    function app() {
+      return {
+        DOM: Rx.Observable.of(
+          svg({width: 150, height: 150}, [
+            h('polygon', {
+              attrs: {
+                class: 'triangle',
+                points: '20 0 20 150 150 20'
+              }
+            }),
+          ])
+        )
+      };
+    }
+
+    const {sinks, sources, run} = Cycle(app, {
+      DOM: makeDOMDriver(createRenderTarget())
+    });
+
+    // Make assertions
+    const selection = sources.DOM.select('.triangle').element$.skip(1).take(1)
+      .subscribe(elements => {
+        assert.strictEqual(elements.length, 1);
+        const triangleElement = elements[0];
+        assert.notStrictEqual(triangleElement, null);
+        assert.notStrictEqual(typeof triangleElement, 'undefined');
+        assert.strictEqual(triangleElement.tagName, 'polygon');
+        done();
+      });
+    run();
+  });
+});

--- a/test/node/mock-dom-source.js
+++ b/test/node/mock-dom-source.js
@@ -69,24 +69,24 @@ describe('mockDOMSource', function () {
       .subscribe(assert.fail, assert.fail, done);
   });
 
-  it('should return empty Observable for select().observable and none is defined', function (done) {
+  it('should return empty Observable for select().element$ and none is defined', function (done) {
     const userEvents = mockDOMSource({
       '.foo': {
         'click': Rx.Observable.just(135)
       }
     });
     let subscribeExecuted = false;
-    userEvents.select('.foo').observable
+    userEvents.select('.foo').element$
       .subscribe(assert.fail, assert.fail, done);
   });
 
-  it('should return defined Observable for select().observable', function (done) {
+  it('should return defined Observable for select().element$', function (done) {
     const mockedDOMSource = mockDOMSource({
       '.foo': {
-        observable: Rx.Observable.just(135)
+        element$: Rx.Observable.just(135)
       }
     });
-    mockedDOMSource.select('.foo').observable
+    mockedDOMSource.select('.foo').element$
       .subscribe(e => {
         assert.strictEqual(e, 135)
         done()
@@ -98,12 +98,12 @@ describe('mockDOMSource', function () {
       '.bar': {
         '.foo': {
           '.baz': {
-            observable: Rx.Observable.just(135)
+            element$: Rx.Observable.just(135)
           }
         }
       }
     });
-    mockedDOMSource.select('.bar').select('.foo').select('.baz').observable
+    mockedDOMSource.select('.bar').select('.foo').select('.baz').element$
       .subscribe(e => {
         assert.strictEqual(e, 135);
         done();
@@ -121,6 +121,6 @@ describe('mockDOMSource', function () {
     const DOM = mockDOMSource({})
     const selector = DOM.select('.something').select('.other')
     assert.strictEqual(selector.events('click') instanceof Rx.Observable, true)
-    assert.strictEqual(selector.observable instanceof Rx.Observable, true)
+    assert.strictEqual(selector.element$ instanceof Rx.Observable, true)
   })
 });

--- a/test/node/rx/html-render.js
+++ b/test/node/rx/html-render.js
@@ -1,0 +1,189 @@
+'use strict';
+/* global describe, it, beforeEach */
+let assert = require('assert');
+let Cycle = require('@cycle/rx-run').default;
+let CycleDOM = require('../../lib/index');
+let Rx = require('rx');
+let {div, h3, h, makeHTMLDriver} = CycleDOM;
+
+describe('HTML Driver', function () {
+  it('should output HTML when given a simple vtree stream', function (done) {
+    function app() {
+      return {
+        html: Rx.Observable.just(div('.test-element', ['Foobar']))
+      };
+    }
+    let {sinks, sources, run} = Cycle(app, {
+      html: makeHTMLDriver()
+    });
+    sources.html.subscribe(html => {
+      assert.strictEqual(html, '<div class="test-element">Foobar</div>');
+      done();
+    });
+    run()
+  });
+
+  it('should make bogus select().events() as sources', function (done) {
+    function app({html}) {
+      assert.strictEqual(typeof html.select, 'function');
+      assert.strictEqual(typeof html.select('whatever').element$.subscribe, 'function');
+      assert.strictEqual(typeof html.select('whatever').events().subscribe, 'function');
+      return {
+        html: Rx.Observable.just(div('.test-element', ['Foobar']))
+      };
+    }
+    let {sinks, sources, run} = Cycle(app, {
+      html: makeHTMLDriver()
+    });
+    sources.html.subscribe(html => {
+      assert.strictEqual(html, '<div class="test-element">Foobar</div>');
+      done();
+    });
+    run();
+  });
+
+  it('should output simple HTML Observable', function (done) {
+    function app() {
+      return {
+        html: Rx.Observable.just(div('.test-element', ['Foobar']))
+      };
+    }
+    let {sinks, sources, run} = Cycle(app, {
+      html: makeHTMLDriver()
+    });
+    sources.html.subscribe(html => {
+      assert.strictEqual(html, '<div class="test-element">Foobar</div>');
+      done();
+    });
+    run();
+  });
+
+  describe('with transposition=true', function () {
+    it('should render a simple nested vtree$ as HTML', function (done) {
+      function app() {
+        return {
+          DOM: Rx.Observable.just(h('div.test-element', [
+            Rx.Observable.just(h('h3.myelementclass'))
+          ]))
+        };
+      }
+      let {sink, sources, run} = Cycle(app, {
+        DOM: makeHTMLDriver({transposition: true})
+      });
+      sources.DOM.subscribe(html => {
+        assert.strictEqual(html,
+          '<div class="test-element">' +
+          '<h3 class="myelementclass"></h3>' +
+          '</div>'
+        );
+        done();
+      });
+      run()
+    });
+
+    it('should render double nested vtree$ as HTML', function (done) {
+      function app() {
+        return {
+          html: Rx.Observable.just(h('div.test-element', [
+            Rx.Observable.just(h('div.a-nice-element', [
+              String('foobar'),
+              Rx.Observable.just(h('h3.myelementclass'))
+            ]))
+          ]))
+        };
+      }
+      let {sinks, sources, run} = Cycle(app, {
+        html: makeHTMLDriver({transposition: true})
+      })
+
+      sources.html.subscribe(html => {
+        assert.strictEqual(html,
+          '<div class="test-element">' +
+          '<div class="a-nice-element">' +
+          'foobar<h3 class="myelementclass"></h3>' +
+          '</div>' +
+          '</div>'
+        );
+        done();
+      });
+      run()
+    });
+
+    it('should HTML-render a nested vtree$ with props', function (done) {
+      function myElement(foobar$) {
+        return foobar$.map(foobar =>
+          h('h3.myelementclass', String(foobar).toUpperCase())
+        );
+      }
+      function app() {
+        return {
+          DOM: Rx.Observable.just(
+            h('div.test-element', [
+              myElement(Rx.Observable.just('yes'))
+            ])
+          )
+        };
+      }
+      let {sink, sources, run} = Cycle(app, {
+        DOM: makeHTMLDriver({transposition: true})
+      });
+
+      sources.DOM.subscribe(html => {
+        assert.strictEqual(html,
+          '<div class="test-element">' +
+          '<h3 class="myelementclass">YES</h3>' +
+          '</div>'
+        );
+        done();
+      });
+      run()
+    });
+
+    it('should render a complex and nested vtree$ as HTML', function (done) {
+      function app() {
+        return {
+          html: Rx.Observable.just(
+            h('.test-element', [
+              h('div', [
+                h('h2.a', 'a'),
+                h('h4.b', 'b'),
+                Rx.Observable.just(h('h1.fooclass'))
+              ]),
+              h('div', [
+                h('h3.c', 'c'),
+                h('div', [
+                  h('p.d', 'd'),
+                  Rx.Observable.just(h('h2.barclass'))
+                ])
+              ])
+            ])
+          )
+        };
+      }
+      let {sink, sources, run} = Cycle(app, {
+        html: makeHTMLDriver({transposition: true})
+      });
+
+      sources.html.subscribe(html => {
+        assert.strictEqual(html,
+          '<div class="test-element">' +
+            '<div>' +
+              '<h2 class="a">a</h2>' +
+              '<h4 class="b">b</h4>' +
+              '<h1 class="fooclass"></h1>' +
+            '</div>' +
+            '<div>' +
+              '<h3 class="c">c</h3>' +
+              '<div>' +
+                '<p class="d">d</p>' +
+                '<h2 class="barclass"></h2>' +
+              '</div>' +
+            '</div>' +
+          '</div>'
+        );
+        done();
+      });
+      run();
+    });
+  });
+});


### PR DESCRIPTION
Adjust DOMSource to return adapted streams
Adjust DOMSource.observable -> DOMSource.element$
Adjust isolateSink to use new Mappable interface# Changes to be committed:
AdJust DOMDriver interface to use streamAdapter
Adjust HTMLDriver interface .observable => element$
Adjust mockDOMSource interface .observable => element$
Adjust transposeVTree to use .map().switch() as its stream library (Rx4/Rx5/most) agnostic
Adjust current tests to use @cycle/rx-run
Move current tests to rx folders and add tests for rxjs (Rx5)