### PR TITLE
Dataset isolation

### DIFF
--- a/src/BubblingSimulator.ts
+++ b/src/BubblingSimulator.ts
@@ -35,7 +35,7 @@ export class BubblingSimulator {
     if (ev.propagationHasBeenStopped) {
       return false;
     }
-    for (let el = <Element> ev.target; el && el !== this.roof; el = el.parentElement) {
+    for (let el = <HTMLElement> ev.target; el && el !== this.roof; el = el.parentElement) {
       if (!this.scopeChecker.isStrictlyInRootScope(el)) {
         continue;
       }

--- a/src/DOMSource.ts
+++ b/src/DOMSource.ts
@@ -6,24 +6,8 @@ import {ElementFinder} from './ElementFinder';
 import {fromEvent} from './fromEvent';
 import {isolateSink, isolateSource} from './isolate';
 
-function isValidString(param: any): boolean {
-  return typeof param === `string` && param.length > 0;
-}
-
-function contains(str: string, match: string): boolean {
-  return str.indexOf(match) > -1;
-}
-
-function isNotTagName(param: any): boolean {
-  return isValidString(param) &&
-    contains(param, `.`) || contains(param, `#`) || contains(param, `:`);
-}
-
-function sortNamespace(a: any, b: any): number {
-  if (isNotTagName(a) && isNotTagName(b)) {
-    return 0;
-  }
-  return isNotTagName(a) ? 1 : -1;
+function sortNamespace(a: string): number {
+  return a.indexOf(`[`) !== -1 ? 1 : -1;
 }
 
 const eventTypesThatDontBubble = [

--- a/src/ElementFinder.ts
+++ b/src/ElementFinder.ts
@@ -1,17 +1,22 @@
+interface MatchesSelector {
+  (element: Element, selector: string): boolean;
+}
+let matchesSelector: MatchesSelector;
+declare var require: any;
+try {
+  matchesSelector = require(`matches-selector`);
+} catch (e) {
+  matchesSelector = <MatchesSelector> Function.prototype;
+}
+
 import {ScopeChecker} from './ScopeChecker';
 
 function getScope(namespace: Array<string>): Array<string> {
-  return namespace.filter(c => c.indexOf(`.cycle-scope`) > -1);
+  return namespace.filter(c => c.indexOf(`[data-cycle-isolate=`) > -1);
 }
 
-function removeDuplicates<T>(arr: Array<T>): Array<T> {
-  const newArray: Array<T> = [];
-  for (let i = arr.length - 1; i >= 0; i--) {
-    if (newArray.indexOf(arr[i]) === -1) {
-      newArray.push(arr[i]);
-    }
-  }
-  return newArray;
+function getSelectors(namespace: Array<string>): Array<string> {
+  return namespace.filter(c => c.indexOf(`[data-cycle-isolate=`) === -1);
 }
 
 function toElArray(input: any): Array<Element> {
@@ -28,20 +33,21 @@ export class ElementFinder {
       return rootElement;
     }
     const scopeChecker = new ScopeChecker(namespace);
-    const scope = getScope(namespace);
-    // Uses global selector && is isolated
-    if (namespace.indexOf(`*`) > -1 && scope.length > 0) {
-      // grab top-level boundary of scope
-      const topNode = rootElement.querySelector(scope.join(` `));
-      // grab all children
-      const childNodes = topNode.getElementsByTagName(`*`);
-      return removeDuplicates([topNode].concat(toElArray(childNodes)))
-        .filter(scopeChecker.isStrictlyInRootScope, scopeChecker);
+    const scope = getScope(namespace).join(` `);
+
+    const selector = getSelectors(namespace).join(` `);
+    let topNode = rootElement;
+    let topNodeMatches: Array<Element> = [];
+
+    if (scope.length > 0) {
+      topNode = rootElement.querySelector(scope) || rootElement;
+      if (matchesSelector(topNode, selector)) {
+        topNodeMatches.push(topNode);
+      }
     }
 
-    return removeDuplicates(
-      toElArray(rootElement.querySelectorAll(namespace.join(' ')))
-        .concat(toElArray(rootElement.querySelectorAll(namespace.join(''))))
-    ).filter(scopeChecker.isStrictlyInRootScope, scopeChecker);
+    return toElArray(topNode.querySelectorAll(selector))
+        .concat(topNodeMatches)
+        .filter(scopeChecker.isStrictlyInRootScope, scopeChecker);
   }
 }

--- a/src/ElementFinder.ts
+++ b/src/ElementFinder.ts
@@ -1,3 +1,5 @@
+import {SCOPE_PREFIX} from './utils';
+
 interface MatchesSelector {
   (element: Element, selector: string): boolean;
 }
@@ -12,11 +14,11 @@ try {
 import {ScopeChecker} from './ScopeChecker';
 
 function getScope(namespace: Array<string>): Array<string> {
-  return namespace.filter(c => c.indexOf(`[data-cycle-isolate=`) > -1);
+  return namespace.filter(c => c.indexOf(`[data-${SCOPE_PREFIX}=`) > -1);
 }
 
 function getSelectors(namespace: Array<string>): Array<string> {
-  return namespace.filter(c => c.indexOf(`[data-cycle-isolate=`) === -1);
+  return namespace.filter(c => c.indexOf(`[data-${SCOPE_PREFIX}=`) === -1);
 }
 
 function toElArray(input: any): Array<Element> {

--- a/src/ScopeChecker.ts
+++ b/src/ScopeChecker.ts
@@ -2,38 +2,27 @@ export class ScopeChecker {
   constructor(private namespace: Array<string>) {
   }
 
-  private someClassIsDomestic(classList: Array<string>): boolean {
-    for (let i = classList.length - 1; i >= 0; i--) {
-      const c = classList[i];
-      const matched = c.match(/cycle-scope-(\S+)/);
-      const classIsInNamespace = this.namespace.indexOf(`.${c}`) !== -1;
-      if (matched && classIsInNamespace) {
-        return true;
-      }
+  private getIsolate(el: HTMLElement) {
+    if (el instanceof SVGElement) {
+      return el.getAttribute(`cycle-isolate`);
     }
-    return false;
+    return (<any> el).dataset.cycleIsolate || null;
   }
 
-  private someClassIsForeign(classList: Array<string>): boolean {
-    for (let i = classList.length - 1; i >= 0; i--) {
-      const c = classList[i];
-      const matched = c.match(/cycle-scope-(\S+)/);
-      const classIsNotInNamespace = this.namespace.indexOf(`.${c}`) === -1;
-      if (matched && classIsNotInNamespace) {
-        return true;
-      }
-    }
-    return false;
+  private checkNamespace(selector: string) {
+    return this.namespace.indexOf(selector);
   }
 
-  public isStrictlyInRootScope(leaf: Element): boolean {
-    for (let el = leaf; !!el; el = el.parentElement) {
-      const classList = el.classList || String.prototype.split.call(el.className, ` `);
-      if (this.someClassIsDomestic(classList)) {
-        return true;
-      }
-      if (this.someClassIsForeign(classList)) {
+  public isStrictlyInRootScope(leaf: HTMLElement): boolean {
+    console.log(this);
+    for (let el = leaf; el; el = el.parentElement) {
+      const isolate = this.getIsolate(el);
+      const selector = `[data-cycle-isolate="${isolate}"]`;
+      if (isolate && this.checkNamespace(selector) === -1) {
         return false;
+      }
+      if (isolate && this.checkNamespace(selector) !== -1) {
+        return true;
       }
     }
     return true;

--- a/src/ScopeChecker.ts
+++ b/src/ScopeChecker.ts
@@ -14,7 +14,6 @@ export class ScopeChecker {
   }
 
   public isStrictlyInRootScope(leaf: HTMLElement): boolean {
-    console.log(this);
     for (let el = leaf; el; el = el.parentElement) {
       const isolate = this.getIsolate(el);
       const selector = `[data-cycle-isolate="${isolate}"]`;

--- a/src/fromEvent.ts
+++ b/src/fromEvent.ts
@@ -1,9 +1,4 @@
-import {
-  Disposable,
-  CompositeDisposable,
-  Observer,
-  Observable,
-} from 'rx';
+import {Observable, Observer} from 'rx';
 
 interface EventListener {
   element: Element;
@@ -12,55 +7,15 @@ interface EventListener {
   useCapture: boolean;
 }
 
-interface CompositeEventListener {
-  element: Element | Array<Element>;
-  eventName: string;
-  handler(ev: Event): void;
-  useCapture: boolean;
-}
-
-function createListener({element, eventName, handler, useCapture}: EventListener) {
-  if (element.addEventListener) {
-    element.addEventListener(eventName, handler, useCapture);
-    return Disposable.create(function removeEventListener() {
-      element.removeEventListener(eventName, handler, useCapture);
-    });
-  }
-  throw new Error(`No listener found`);
-}
-
-function createEventListener(listener: CompositeEventListener): CompositeDisposable {
-  const disposables = new CompositeDisposable();
-
-  if (Array.isArray(listener.element)) {
-    const elements: Array<Element> = <Array<Element>> listener.element;
-    for (let i = 0, len = elements.length; i < len; i++) {
-      disposables.add(
-        createEventListener({
-          element: listener.element[i],
-          eventName: listener.eventName,
-          handler: listener.handler,
-          useCapture: listener.useCapture,
-        })
-      );
-    }
-  } else if (listener.element) {
-    disposables.add(createListener(<EventListener> listener));
-  }
-  return disposables;
-}
-
 export function fromEvent(element: Element,
                           eventName: string,
                           useCapture = false): Observable<Event> {
   return Observable.create<Event>(function subscribe(observer: Observer<Event>) {
-    return createEventListener({
-      element,
-      eventName,
-      handler: function handler(ev: Event) {
-        observer.onNext(ev);
-      },
-      useCapture,
-    });
+    function next(event: Event) { observer.onNext(event); };
+
+    element.addEventListener(eventName, next, useCapture);
+
+    return () => element.removeEventListener(eventName, next, useCapture);
+
   }).share();
 }

--- a/src/isolate.ts
+++ b/src/isolate.ts
@@ -3,7 +3,7 @@ import {SCOPE_PREFIX} from './utils';
 import {DOMSource} from './DOMSource';
 
 export function isolateSource(source: DOMSource, scope: string): DOMSource {
-  return source.select(`.${SCOPE_PREFIX}${scope}`);
+  return source.select(`[data-${SCOPE_PREFIX}="${scope}"]`);
 }
 
 interface Mappable<T, R> {
@@ -12,15 +12,7 @@ interface Mappable<T, R> {
 
 export function isolateSink(sink: any, scope: string): any {
   return <Mappable<VNode, VNode>>sink.map((vTree: VNode) => {
-    if (vTree.sel.indexOf(`${SCOPE_PREFIX}${scope}`) === -1) {
-      if (vTree.data && vTree.data.ns) { // svg elements
-        const attrs = vTree.data.attrs || {};
-        attrs.class = `${attrs.class || ''} ${SCOPE_PREFIX}${scope}`;
-        vTree.data.attrs = attrs;
-      } else {
-        vTree.sel = `${vTree.sel}.${SCOPE_PREFIX}${scope}`;
-      }
-    }
+    vTree.data.isolate = scope;
     return vTree;
   });
 }

--- a/src/isolateModule.ts
+++ b/src/isolateModule.ts
@@ -1,0 +1,40 @@
+import {VNode} from 'snabbdom';
+
+function setScope(elm: HTMLElement, data: any, scope: string) {
+  if (data.ns) { // is SVG
+    elm.setAttribute(`cycleIsolate`, scope);
+  } else {
+    (<any> elm).dataset.cycleIsolate = scope;
+  }
+}
+
+function removeScope(elm: HTMLElement, data: any, scope: string) {
+  if (data.ns) { // is SVG
+    elm.removeAttribute(`cycleIsolate`);
+  } else {
+    delete (<any> elm).dataset.cycleIsolate;
+  }
+}
+
+function update(oldVNode: VNode, vNode: VNode) {
+  const {data: oldData = {}} = oldVNode;
+  const {elm, data = {}} = vNode;
+
+  const oldIsolate = oldData.isolate || ``;
+  const isolate = data.isolate || ``;
+
+  if (isolate && isolate !== oldIsolate) {
+    setScope((<HTMLElement> elm), data, isolate);
+  }
+  if (oldIsolate && !isolate) {
+    removeScope((<HTMLElement> elm), data, isolate);
+  }
+}
+
+const IsolateModule: Object = {
+  // init: (vNode) => update({}, vNode),
+  create: update,
+  update,
+};
+
+export {IsolateModule}

--- a/src/makeDOMDriver.ts
+++ b/src/makeDOMDriver.ts
@@ -5,6 +5,7 @@ import {DOMSource} from './DOMSource';
 import {VNodeWrapper} from './VNodeWrapper';
 import {domSelectorParser} from './utils';
 import defaultModules from './modules';
+import {IsolateModule} from './isolateModule';
 import {makeTransposeVNode} from './transposition';
 import RxAdapter from '@cycle/rx-adapter';
 
@@ -27,7 +28,7 @@ function domDriverInputGuard(view$: Observable<any>): void {
 }
 
 export interface DOMDriverOptions {
-  modules?: Object;
+  modules?: Array<Object>;
   onError?(msg: string): void;
   transposition?: boolean;
 }
@@ -45,7 +46,7 @@ function makeDOMDriver(container: string | Element, options?: DOMDriverOptions):
   const transposition = options.transposition || false;
   const modules = options.modules || defaultModules;
   const onError = options.onError || defaultOnErrorFn;
-  const patch = init(modules);
+  const patch = init(modules.concat(IsolateModule));
   const rootElement = domSelectorParser(container);
   const vnodeWrapper = new VNodeWrapper(rootElement);
   makeDOMDriverInputGuard(modules, onError);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,7 +6,7 @@ function isElement(obj: any) {
     typeof obj.nodeName === `string`;
 }
 
-export const SCOPE_PREFIX = `cycle-scope-`;
+export const SCOPE_PREFIX = `cycle-isolate`;
 
 export function domSelectorParser(selectors: any) {
   const domElement = typeof selectors === `string` ?

--- a/test/browser/isolation.js
+++ b/test/browser/isolation.js
@@ -23,7 +23,7 @@ describe('isolateSource', function () {
         DOM: Rx.Observable.of(
           h3('.top-most', [
             h2('.bar', 'Wrong'),
-            div('.cycle-scope-foo', [
+            div({attrs: {'data-cycle-isolate': 'foo'}}, [
               h4('.bar', 'Correct')
             ])
           ])
@@ -75,7 +75,7 @@ describe('isolateSource', function () {
 });
 
 describe('isolateSink', function () {
-  it('should add a className to the vtree sink', function (done) {
+  it('should add a dataset to the vtree sink', function (done) {
     function app(sources) {
       const vtree$ = Rx.Observable.of(h3('.top-most'));
       return {
@@ -95,80 +95,13 @@ describe('isolateSink', function () {
         assert.notStrictEqual(element, null);
         assert.notStrictEqual(typeof element, 'undefined');
         assert.strictEqual(element.tagName, 'H3');
-        assert.strictEqual(element.className, 'top-most cycle-scope-foo');
+        assert.strictEqual(element.dataset.cycleIsolate, 'foo');
         setTimeout(() => {
           dispose();
           done();
         })
       });
     dispose = run()
-  });
-
-  it('should add a className to a vtree sink that had no className', function (done) {
-    function app(sources) {
-      const vtree$ = Rx.Observable.of(h3());
-      return {
-        DOM: sources.DOM.isolateSink(vtree$, 'foo'),
-      };
-    }
-
-    const {sinks, sources, run} = Cycle(app, {
-      DOM: makeDOMDriver(createRenderTarget())
-    });
-
-    let dispose;
-    // Make assertions
-    sources.DOM.select(':root').element$.skip(1).take(1)
-      .subscribe(function (root) {
-        const element = root.querySelector('h3');
-        assert.notStrictEqual(element, null);
-        assert.notStrictEqual(typeof element, 'undefined');
-        assert.strictEqual(element.tagName, 'H3');
-        assert.strictEqual(element.className, 'cycle-scope-foo');
-        setTimeout(() => {
-          dispose();
-          done();
-        });
-      });
-    dispose = run();
-  });
-
-  it('should not redundantly repeat the scope className', function (done) {
-    function app(sources) {
-      const vtree1$ = Rx.Observable.of(span('.tab1', 'Hi'));
-      const vtree2$ = Rx.Observable.of(span('.tab2', 'Hello'));
-      const first$ = sources.DOM.isolateSink(vtree1$, '1');
-      const second$ = sources.DOM.isolateSink(vtree2$, '2');
-      const switched$ = Rx.Observable.concat(
-        Rx.Observable.of(1).delay(50),
-        Rx.Observable.of(2).delay(50),
-        Rx.Observable.of(1).delay(50),
-        Rx.Observable.of(2).delay(50),
-        Rx.Observable.of(1).delay(50),
-        Rx.Observable.of(2).delay(50)
-      ).switchMap(i => i === 1 ? first$ : second$);
-      return {
-        DOM: switched$
-      };
-    }
-
-    const {sinks, sources, run} = Cycle(app, {
-      DOM: makeDOMDriver(createRenderTarget())
-    });
-
-    let dispose;
-    // Make assertions
-    sources.DOM.select(':root').element$.skip(5).take(1)
-      .subscribe(function (root) {
-        const element = root.querySelector('span');
-        assert.notStrictEqual(element, null);
-        assert.notStrictEqual(typeof element, 'undefined');
-        assert.strictEqual(element.tagName, 'SPAN');
-        assert.strictEqual(element.className, 'tab1 cycle-scope-1');
-        dispose();
-        done();
-      });
-    dispose = run();
   });
 });
 


### PR DESCRIPTION
Adds a new IsolationModule to handle setting the proper data-* attribute on an
element whether it is a HTMLElement or SVGElement.
Always use IsolationModule in the patch function.
Adjust DOMSource, ScopeChecker, BubblingSimulator, and ElementFinder to work with
the `data-cycle-isolate` attribute.