### PR TITLE
feat(isolation): update isolation to not use css selectors

### DIFF
--- a/src/BubblingSimulator.ts
+++ b/src/BubblingSimulator.ts
@@ -1,4 +1,6 @@
 import {ScopeChecker} from './ScopeChecker';
+import {IsolateModule} from './isolateModule';
+import {getScope, getSelectors} from './utils';
 
 interface MatchesSelector {
   (element: Element, selector: string): boolean;
@@ -17,17 +19,18 @@ export interface PatchedEvent extends Event {
 }
 
 export class BubblingSimulator {
-  private descendantSel: string;
-  private topSel: string;
+  private scope: string;
+  private selector: string;
   private roof: HTMLElement;
   private scopeChecker: ScopeChecker;
 
   constructor(private namespace: Array<string>,
-              private rootEl: Element) {
-    this.descendantSel = namespace.join(` `);
-    this.topSel = namespace.join(``);
+              private rootEl: Element,
+              isolateModule: IsolateModule) {
+    this.scope = getScope(namespace);
+    this.selector = getSelectors(namespace);
     this.roof = rootEl.parentElement;
-    this.scopeChecker = new ScopeChecker(namespace);
+    this.scopeChecker = new ScopeChecker(this.scope, isolateModule);
   }
 
   shouldPropagate(ev: PatchedEvent): boolean {
@@ -39,7 +42,7 @@ export class BubblingSimulator {
       if (!this.scopeChecker.isStrictlyInRootScope(el)) {
         continue;
       }
-      if (matchesSelector(el, this.descendantSel) || matchesSelector(el, this.topSel)) {
+      if (matchesSelector(el, this.selector)) {
         this.mutateEventCurrentTarget(ev, el);
         return true;
       }

--- a/src/DOMSource.ts
+++ b/src/DOMSource.ts
@@ -60,14 +60,16 @@ export class DOMSource {
               private disposable?: Disposable) {
   }
 
-  get element$(): any {
+  get elements(): any {
     if (this._namespace.length === 0) {
       return this.runStreamAdapter.adapt(
         this.rootElement$,
         RxAdapter.streamSubscribe
       );
     } else {
-      const elementFinder = new ElementFinder(this._namespace, this.isolateModule);
+      const elementFinder = new ElementFinder(
+        this._namespace, this.isolateModule
+      );
       return this.runStreamAdapter.adapt(
         this.rootElement$.map(elementFinder.call, elementFinder),
         RxAdapter.streamSubscribe
@@ -88,7 +90,12 @@ export class DOMSource {
     const childNamespace = trimmedSelector === `:root` ?
       this._namespace :
       this._namespace.concat(trimmedSelector);
-    return new DOMSource(this.rootElement$, this.runStreamAdapter, childNamespace, this.isolateModule);
+    return new DOMSource(
+      this.rootElement$,
+      this.runStreamAdapter,
+      childNamespace,
+      this.isolateModule
+    );
   }
 
   events(eventType: string, options: EventsFnOptions = {}): any {
@@ -105,7 +112,9 @@ export class DOMSource {
         if (!namespace || namespace.length === 0) {
           return fromEvent(rootElement, eventType, useCapture);
         }
-        const bubblingSimulator = new BubblingSimulator(namespace, rootElement, this.isolateModule);
+        const bubblingSimulator = new BubblingSimulator(
+          namespace, rootElement, this.isolateModule
+        );
         return fromEvent(rootElement, eventType, useCapture)
           .filter(bubblingSimulator.shouldPropagate, bubblingSimulator);
       })

--- a/src/DOMSource.ts
+++ b/src/DOMSource.ts
@@ -5,26 +5,7 @@ import {BubblingSimulator} from './BubblingSimulator';
 import {ElementFinder} from './ElementFinder';
 import {fromEvent} from './fromEvent';
 import {isolateSink, isolateSource} from './isolate';
-
-function isValidString(param: any): boolean {
-  return typeof param === `string` && param.length > 0;
-}
-
-function contains(str: string, match: string): boolean {
-  return str.indexOf(match) > -1;
-}
-
-function isNotTagName(param: any): boolean {
-  return isValidString(param) &&
-    contains(param, `.`) || contains(param, `#`) || contains(param, `:`);
-}
-
-function sortNamespace(a: any, b: any): number {
-  if (isNotTagName(a) && isNotTagName(b)) {
-    return 0;
-  }
-  return isNotTagName(a) ? 1 : -1;
-}
+import {IsolateModule} from './isolateModule';
 
 const eventTypesThatDontBubble = [
   `load`,
@@ -75,18 +56,18 @@ export class DOMSource {
   constructor(private rootElement$: Observable<any>,
               private runStreamAdapter: StreamAdapter,
               private _namespace: Array<string> = [],
+              public isolateModule: IsolateModule,
               private disposable?: Disposable) {
   }
 
   get element$(): any {
-    console.log(this.runStreamAdapter);
     if (this._namespace.length === 0) {
       return this.runStreamAdapter.adapt(
         this.rootElement$,
         RxAdapter.streamSubscribe
       );
     } else {
-      const elementFinder = new ElementFinder(this._namespace);
+      const elementFinder = new ElementFinder(this._namespace, this.isolateModule);
       return this.runStreamAdapter.adapt(
         this.rootElement$.map(elementFinder.call, elementFinder),
         RxAdapter.streamSubscribe
@@ -106,8 +87,8 @@ export class DOMSource {
     const trimmedSelector = selector.trim();
     const childNamespace = trimmedSelector === `:root` ?
       this._namespace :
-      this._namespace.concat(trimmedSelector).sort(sortNamespace);
-    return new DOMSource(this.rootElement$, this.runStreamAdapter, childNamespace);
+      this._namespace.concat(trimmedSelector);
+    return new DOMSource(this.rootElement$, this.runStreamAdapter, childNamespace, this.isolateModule);
   }
 
   events(eventType: string, options: EventsFnOptions = {}): any {
@@ -124,7 +105,7 @@ export class DOMSource {
         if (!namespace || namespace.length === 0) {
           return fromEvent(rootElement, eventType, useCapture);
         }
-        const bubblingSimulator = new BubblingSimulator(namespace, rootElement);
+        const bubblingSimulator = new BubblingSimulator(namespace, rootElement, this.isolateModule);
         return fromEvent(rootElement, eventType, useCapture)
           .filter(bubblingSimulator.shouldPropagate, bubblingSimulator);
       })
@@ -140,6 +121,7 @@ export class DOMSource {
     if (this.disposable) {
       this.disposable.dispose();
     }
+    this.isolateModule.reset();
   }
 
   public isolateSource: (source: DOMSource, scope: string) => DOMSource = isolateSource;

--- a/src/ScopeChecker.ts
+++ b/src/ScopeChecker.ts
@@ -1,39 +1,18 @@
+import {IsolateModule} from './isolateModule';
+
 export class ScopeChecker {
-  constructor(private namespace: Array<string>) {
-  }
-
-  private someClassIsDomestic(classList: Array<string>): boolean {
-    for (let i = classList.length - 1; i >= 0; i--) {
-      const c = classList[i];
-      const matched = c.match(/cycle-scope-(\S+)/);
-      const classIsInNamespace = this.namespace.indexOf(`.${c}`) !== -1;
-      if (matched && classIsInNamespace) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private someClassIsForeign(classList: Array<string>): boolean {
-    for (let i = classList.length - 1; i >= 0; i--) {
-      const c = classList[i];
-      const matched = c.match(/cycle-scope-(\S+)/);
-      const classIsNotInNamespace = this.namespace.indexOf(`.${c}`) === -1;
-      if (matched && classIsNotInNamespace) {
-        return true;
-      }
-    }
-    return false;
+  constructor(private scope: string,
+              private isolateModule: IsolateModule) {
   }
 
   public isStrictlyInRootScope(leaf: Element): boolean {
-    for (let el = leaf; !!el; el = el.parentElement) {
-      const classList = el.classList || String.prototype.split.call(el.className, ` `);
-      if (this.someClassIsDomestic(classList)) {
-        return true;
-      }
-      if (this.someClassIsForeign(classList)) {
+    for (let el = leaf; el; el = el.parentElement) {
+      const scope = this.isolateModule.isIsolatedElement(el);
+      if (scope && scope !== this.scope) {
         return false;
+      }
+      if (scope) {
+        return true;
       }
     }
     return true;

--- a/src/isolate.ts
+++ b/src/isolate.ts
@@ -3,7 +3,7 @@ import {SCOPE_PREFIX} from './utils';
 import {DOMSource} from './DOMSource';
 
 export function isolateSource(source: DOMSource, scope: string): DOMSource {
-  return source.select(`.${SCOPE_PREFIX}${scope}`);
+  return source.select(SCOPE_PREFIX + scope);
 }
 
 interface Mappable<T, R> {
@@ -12,15 +12,7 @@ interface Mappable<T, R> {
 
 export function isolateSink(sink: any, scope: string): any {
   return <Mappable<VNode, VNode>>sink.map((vTree: VNode) => {
-    if (vTree.sel.indexOf(`${SCOPE_PREFIX}${scope}`) === -1) {
-      if (vTree.data && vTree.data.ns) { // svg elements
-        const attrs = vTree.data.attrs || {};
-        attrs.class = `${attrs.class || ''} ${SCOPE_PREFIX}${scope}`;
-        vTree.data.attrs = attrs;
-      } else {
-        vTree.sel = `${vTree.sel}.${SCOPE_PREFIX}${scope}`;
-      }
-    }
+    vTree.data.isolate = SCOPE_PREFIX + scope;
     return vTree;
   });
 }

--- a/src/isolateModule.ts
+++ b/src/isolateModule.ts
@@ -1,0 +1,82 @@
+import {VNode} from 'snabbdom';
+
+export class IsolateModule {
+  constructor (private isolatedElements: Map<string, Element>) {
+  }
+
+  private setScope(elm: Element, scope: string) {
+    this.isolatedElements.set(scope, elm);
+  }
+
+  private removeScope(scope: string) {
+    this.isolatedElements.delete(scope);
+  }
+
+  getIsolatedElement(scope: string) {
+    return this.isolatedElements.get(scope);
+  }
+
+  isIsolatedElement(elm: Element): string | boolean {
+    const elements = Array.from(this.isolatedElements.entries());
+    for (let i = 0; i < elements.length; ++i) {
+      if (elm === elements[i][1]) {
+        return elements[i][0];
+      }
+    }
+    return false;
+  }
+
+  reset() {
+    this.isolatedElements.clear();
+  }
+
+  createModule() {
+    const self = this;
+    return {
+      create(oldVNode: VNode, vNode: VNode) {
+        const {data: oldData = {}} = oldVNode;
+        const {elm, data = {}} = vNode;
+        const oldIsolate = oldData.isolate || ``;
+        const isolate = data.isolate || ``;
+        if (isolate) {
+          console.log('has isolate', elm);
+          if (oldIsolate) { self.removeScope(oldIsolate); }
+          self.setScope(elm, isolate);
+        }
+        if (oldIsolate && !isolate) {
+          self.removeScope(isolate);
+        }
+      },
+
+      update(oldVNode: VNode, vNode: VNode) {
+        const {data: oldData = {}} = oldVNode;
+        const {elm, data = {}} = vNode;
+        const oldIsolate = oldData.isolate || ``;
+        const isolate = data.isolate || ``;
+        if (isolate) {
+          console.log('has isolate', elm);
+          if (oldIsolate) { self.removeScope(oldIsolate); }
+          self.setScope(elm, isolate);
+        }
+        if (oldIsolate && !isolate) {
+          self.removeScope(isolate);
+        }
+      },
+
+      remove({data = {}}, cb: Function) {
+        if ((<any> data).isolate) {
+          self.removeScope((<any> data).isolate);
+        }
+        cb();
+      },
+
+      destroy({data = {}}) {
+        if ((<any> data).isolate) {
+          self.removeScope((<any> data).isolate);
+        }
+      }
+    };
+  }
+
+  // snabbdom module stuff
+}

--- a/src/makeHTMLDriver.ts
+++ b/src/makeHTMLDriver.ts
@@ -6,12 +6,12 @@ import {makeTransposeVNode} from './transposition';
 const toHTML: (vnode: VNode) => string = require('snabbdom-to-html');
 
 export class HTMLSource {
-  public element$: any;
+  public elements: any;
   private _empty$: any;
 
   constructor(vnode$: Observable<VNode>,
               private runStreamAdapter: StreamAdapter) {
-    this.element$ = vnode$.last().map(toHTML);
+    this.elements = vnode$.last().map(toHTML);
     this._empty$ = runStreamAdapter.adapt(Observable.empty(), RxAdapter.streamSubscribe);
   }
 

--- a/src/mockDOMSource.ts
+++ b/src/mockDOMSource.ts
@@ -1,18 +1,18 @@
 import {Observable} from 'rx';
 
 export interface DOMSelection {
-  element$: Observable<any>;
+  elements: Observable<any>;
   events: (eventType: string) => Observable<any>;
 }
 
 export class MockedDOMSource {
-  public element$: Observable<any>;
+  public elements: Observable<any>;
 
   constructor(private _mockConfig: Object) {
-    if (_mockConfig['element$']) {
-      this.element$ = _mockConfig['element$'];
+    if (_mockConfig['elements']) {
+      this.elements = _mockConfig['elements'];
     } else {
-      this.element$ = Observable.empty();
+      this.elements = Observable.empty();
     }
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,3 +21,15 @@ export function domSelectorParser(selectors: any) {
   }
   return domElement;
 }
+
+export function getScope(namespace: String[]): string {
+  return  namespace
+    .filter(c => c.indexOf(SCOPE_PREFIX) > -1)
+    .slice(-1) // only need the latest, most specific, isolated boundary
+    .join(` `)
+    .trim();
+}
+
+export function getSelectors(namespace: String[]): string {
+  return namespace.filter(c => c.indexOf(SCOPE_PREFIX) === -1).join(` `);
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,7 +6,7 @@ function isElement(obj: any) {
     typeof obj.nodeName === `string`;
 }
 
-export const SCOPE_PREFIX = `cycle-scope-`;
+export const SCOPE_PREFIX = `$$CYCLEDOM$$-`;
 
 export function domSelectorParser(selectors: any) {
   const domElement = typeof selectors === `string` ?
@@ -23,11 +23,10 @@ export function domSelectorParser(selectors: any) {
 }
 
 export function getScope(namespace: String[]): string {
-  return  namespace
+  return namespace
     .filter(c => c.indexOf(SCOPE_PREFIX) > -1)
     .slice(-1) // only need the latest, most specific, isolated boundary
-    .join(` `)
-    .trim();
+    .join(``);
 }
 
 export function getSelectors(namespace: String[]): string {

--- a/test/browser/dom-driver.js
+++ b/test/browser/dom-driver.js
@@ -141,7 +141,7 @@ describe('DOM Driver', function () {
     });
 
     let dispose;
-    sources.DOM.select(':root').element$.skip(1).subscribe(function (root) {
+    sources.DOM.select(':root').elements.skip(1).subscribe(function (root) {
       const selectEl = root.querySelector('.target');
       assert.notStrictEqual(selectEl, null);
       assert.notStrictEqual(typeof selectEl, 'undefined');

--- a/test/browser/events.js
+++ b/test/browser/events.js
@@ -36,7 +36,7 @@ describe('DOMSource.events()', function () {
       done();
     });
     // Make assertions
-    sources.DOM.select(':root').element$.skip(1).take(1).subscribe(function (root) {
+    sources.DOM.select(':root').elements.skip(1).take(1).subscribe(function (root) {
       const myElement = root.querySelector('.myelementclass');
       assert.notStrictEqual(myElement, null);
       assert.notStrictEqual(typeof myElement, 'undefined');
@@ -68,7 +68,7 @@ describe('DOMSource.events()', function () {
       done();
     });
 
-    sources.DOM.select(':root').element$.skip(1).take(1).subscribe(function (root) {
+    sources.DOM.select(':root').elements.skip(1).take(1).subscribe(function (root) {
       const myElement = root.querySelector('.myelementclass');
       assert.notStrictEqual(myElement, null);
       assert.notStrictEqual(typeof myElement, 'undefined');
@@ -100,7 +100,7 @@ describe('DOMSource.events()', function () {
       done();
     });
 
-    sources.DOM.select(':root').element$.skip(1).take(1)
+    sources.DOM.select(':root').elements.skip(1).take(1)
       .subscribe(function (root) {
         const myElement = root.querySelector('#myElementId');
         assert.notStrictEqual(myElement, null);
@@ -135,7 +135,7 @@ describe('DOMSource.events()', function () {
       done();
     });
 
-    sources.DOM.select(':root').element$.skip(1).take(1).subscribe(function (root) {
+    sources.DOM.select(':root').elements.skip(1).take(1).subscribe(function (root) {
       const myElement = root.querySelector('.myelementclass');
       assert.notStrictEqual(myElement, null);
       assert.notStrictEqual(typeof myElement, 'undefined');
@@ -174,7 +174,7 @@ describe('DOMSource.events()', function () {
       done();
     });
 
-    sources.DOM.select(':root').element$.skip(1).take(1)
+    sources.DOM.select(':root').elements.skip(1).take(1)
       .subscribe(function (root) {
         const wrongElement = root.querySelector('.bar');
         const correctElement = root.querySelector('.foo .bar');
@@ -222,7 +222,7 @@ describe('DOMSource.events()', function () {
         done();
       });
 
-    sources.DOM.select(':root').element$.skip(1).take(1)
+    sources.DOM.select(':root').elements.skip(1).take(1)
       .subscribe(function (root) {
         const firstElem = root.querySelector('.first');
         const secondElem = root.querySelector('.second');
@@ -262,7 +262,7 @@ describe('DOMSource.events()', function () {
       done();
     });
 
-    sources.DOM.select(':root').element$.skip(3).take(1)
+    sources.DOM.select(':root').elements.skip(3).take(1)
       .subscribe(function (root) {
         const myElement = root.querySelector('.blosh');
         assert.notStrictEqual(myElement, null);
@@ -306,7 +306,7 @@ describe('DOMSource.events()', function () {
       done();
     });
     // Make assertions
-    sources.DOM.select(':root').element$.skip(1).take(1).subscribe(function (root) {
+    sources.DOM.select(':root').elements.skip(1).take(1).subscribe(function (root) {
       const child = root.querySelector('.child');
       assert.notStrictEqual(child, null);
       assert.notStrictEqual(typeof child, 'undefined');
@@ -341,7 +341,7 @@ describe('DOMSource.events()', function () {
       done();
     });
 
-    sources.DOM.select(':root').element$.skip(1).take(1).subscribe(root => {
+    sources.DOM.select(':root').elements.skip(1).take(1).subscribe(root => {
       const form = root.querySelector('.form');
       setTimeout(() => form.reset());
     });
@@ -386,7 +386,7 @@ describe('DOMSource.events()', function () {
     sources.DOM.select('.clickable').events('click', {useCapture: false})
       .subscribe(assert.fail);
 
-    sources.DOM.select(':root').element$.skip(1).take(1).subscribe(root => {
+    sources.DOM.select(':root').elements.skip(1).take(1).subscribe(root => {
       const clickable = root.querySelector('.clickable');
       setTimeout(() => click(clickable));
     });
@@ -424,7 +424,7 @@ describe('DOMSource.events()', function () {
         done('should not capture blur events if useCapture is false')
       );
 
-    sources.DOM.select(':root').element$.skip(1).take(1).subscribe(root => {
+    sources.DOM.select(':root').elements.skip(1).take(1).subscribe(root => {
       const correct = root.querySelector('.correct');
       const wrong = root.querySelector('.wrong');
       const dummy = root.querySelector('.dummy');
@@ -467,7 +467,7 @@ describe('DOMSource.events()', function () {
         done('should not capture blur events if useCapture is false')
       );
 
-    sources.DOM.select(':root').element$.skip(1).take(1).subscribe(root => {
+    sources.DOM.select(':root').elements.skip(1).take(1).subscribe(root => {
       const correct = root.querySelector('.correct');
       const wrong = root.querySelector('.wrong');
       const dummy = root.querySelector('.dummy');

--- a/test/browser/render.js
+++ b/test/browser/render.js
@@ -34,7 +34,7 @@ describe('DOM Rendering', function () {
     });
 
     let dispose;
-    sources.DOM.select(':root').element$.skip(1).take(1).subscribe(function (root) {
+    sources.DOM.select(':root').elements.skip(1).take(1).subscribe(function (root) {
       const selectEl = root.querySelector('.my-class');
       assert.notStrictEqual(selectEl, null);
       assert.notStrictEqual(typeof selectEl, 'undefined');
@@ -65,7 +65,7 @@ describe('DOM Rendering', function () {
     });
 
     let dispose;
-    sources.DOM.select(':root').element$.skip(1).take(1).subscribe(function (root) {
+    sources.DOM.select(':root').elements.skip(1).take(1).subscribe(function (root) {
       const selectEl = root.querySelector('.my-class');
       assert.notStrictEqual(selectEl, null);
       assert.notStrictEqual(typeof selectEl, 'undefined');
@@ -101,7 +101,7 @@ describe('DOM Rendering', function () {
 
     let dispose;
     // Assert it
-    sources.DOM.select(':root').element$.skip(1).take(1).subscribe(function (root) {
+    sources.DOM.select(':root').elements.skip(1).take(1).subscribe(function (root) {
       const selectEl = root.querySelector('h4');
       assert.notStrictEqual(selectEl, null);
       assert.notStrictEqual(typeof selectEl, 'undefined');

--- a/test/browser/select.js
+++ b/test/browser/select.js
@@ -35,7 +35,7 @@ describe('DOMSource.select()', function () {
     });
 
     let dispose;
-    sources.DOM.select(':root').element$.skip(1).take(1).subscribe(root => {
+    sources.DOM.select(':root').elements.skip(1).take(1).subscribe(root => {
       const classNameRegex = /top\-most/;
       assert.strictEqual(root.tagName, 'DIV');
       const child = root.children[0];
@@ -64,8 +64,8 @@ describe('DOMSource.select()', function () {
     // Make assertions
     const selection = sources.DOM.select('.myelementclass');
     assert.strictEqual(typeof selection, 'object');
-    assert.strictEqual(typeof selection.element$, 'object');
-    assert.strictEqual(typeof selection.element$.subscribe, 'function');
+    assert.strictEqual(typeof selection.elements, 'object');
+    assert.strictEqual(typeof selection.elements.subscribe, 'function');
     assert.strictEqual(typeof selection.events, 'function');
     dispose();
     done();
@@ -84,7 +84,7 @@ describe('DOMSource.select()', function () {
 
     let dispose;
     // Make assertions
-    sources.DOM.select('.myelementclass').element$.skip(1).take(1)
+    sources.DOM.select('.myelementclass').elements.skip(1).take(1)
       .subscribe(elements => {
         assert.notStrictEqual(elements, null);
         assert.notStrictEqual(typeof elements, 'undefined');
@@ -122,7 +122,7 @@ describe('DOMSource.select()', function () {
 
     let dispose;
     // Make assertions
-    sources.DOM.select('.foo').select('.bar').element$.skip(1).take(1)
+    sources.DOM.select('.foo').select('.bar').elements.skip(1).take(1)
       .subscribe(elements => {
         assert.strictEqual(elements.length, 1);
         const element = elements[0];
@@ -159,7 +159,7 @@ describe('DOMSource.select()', function () {
     });
 
     // Make assertions
-    const selection = sources.DOM.select('.triangle').element$.skip(1).take(1)
+    const selection = sources.DOM.select('.triangle').elements.skip(1).take(1)
       .subscribe(elements => {
         assert.strictEqual(elements.length, 1);
         const triangleElement = elements[0];

--- a/test/browser/transposition.js
+++ b/test/browser/transposition.js
@@ -32,14 +32,14 @@ describe('DOM rendering with transposition', function () {
     });
 
     let dispose;
-    sources.DOM.select('.myelementclass').element$.skip(1).first() // 1st
+    sources.DOM.select('.myelementclass').elements.skip(1).first() // 1st
       .subscribe(function (elements) {
         const myelement = elements[0];
         assert.notStrictEqual(myelement, null);
         assert.strictEqual(myelement.tagName, 'H3');
         assert.strictEqual(myelement.textContent, '123');
       });
-    sources.DOM.select('.myelementclass').element$.skip(2).first() // 2nd
+    sources.DOM.select('.myelementclass').elements.skip(2).first() // 2nd
       .subscribe(function (elements) {
         const myelement = elements[0];
         assert.notStrictEqual(myelement, null);
@@ -66,14 +66,14 @@ describe('DOM rendering with transposition', function () {
     });
 
     let dispose;
-    sources.DOM.select('.myelementclass').element$.skip(1).first() // 1st
+    sources.DOM.select('.myelementclass').elements.skip(1).first() // 1st
       .subscribe(function (elements) {
         const myelement = elements[0];
         assert.notStrictEqual(myelement, null);
         assert.strictEqual(myelement.tagName, 'H3');
         assert.strictEqual(myelement.textContent, '123');
       });
-    sources.DOM.select('.myelementclass').element$.skip(2).first() // 1st
+    sources.DOM.select('.myelementclass').elements.skip(2).first() // 1st
       .subscribe(function (elements) {
         const myelement = elements[0];
         assert.notStrictEqual(myelement, null);
@@ -105,7 +105,7 @@ describe('DOM rendering with transposition', function () {
     });
 
     let dispose;
-    sources.DOM.select(':root').element$.skip(1).take(1).subscribe(function (root) {
+    sources.DOM.select(':root').elements.skip(1).take(1).subscribe(function (root) {
       const selectEl = root.querySelector('.child');
       assert.notStrictEqual(selectEl, null);
       assert.notStrictEqual(typeof selectEl, 'undefined');
@@ -145,7 +145,7 @@ describe('DOM rendering with transposition', function () {
     });
 
     let dispose;
-    sources.DOM.select(':root').element$.skip(1).take(1).subscribe(function (root) {
+    sources.DOM.select(':root').elements.skip(1).take(1).subscribe(function (root) {
       const selectEl = root.querySelector('.grandchild');
       assert.notStrictEqual(selectEl, null);
       assert.notStrictEqual(typeof selectEl, 'undefined');
@@ -179,7 +179,7 @@ describe('DOM rendering with transposition', function () {
     });
 
     let dispose
-    sources.DOM.select(':root').element$.skip(1).take(1).subscribe(function (root) {
+    sources.DOM.select(':root').elements.skip(1).take(1).subscribe(function (root) {
       const selectEl = root.querySelector('.child');
       assert.notStrictEqual(selectEl, null);
       assert.notStrictEqual(typeof selectEl, 'undefined');
@@ -215,7 +215,7 @@ describe('DOM rendering with transposition', function () {
 
     let expected = ['1/1','2/1','2/2'];
 
-    sources.DOM.select('.target').element$
+    sources.DOM.select('.target').elements
       .skip(1)
       .map(els => els[0].innerHTML)
       .subscribe((x) => {

--- a/test/node/html-render.js
+++ b/test/node/html-render.js
@@ -16,7 +16,7 @@ describe('HTML Driver', function () {
     let {sinks, sources, run} = Cycle(app, {
       html: makeHTMLDriver()
     });
-    sources.html.element$.subscribe(html => {
+    sources.html.elements.subscribe(html => {
       assert.strictEqual(html, '<div class="test-element">Foobar</div>');
       done();
     });
@@ -26,7 +26,7 @@ describe('HTML Driver', function () {
   it('should make bogus select().events() as sources', function (done) {
     function app({html}) {
       assert.strictEqual(typeof html.select, 'function');
-      assert.strictEqual(typeof html.select('whatever').element$.subscribe, 'function');
+      assert.strictEqual(typeof html.select('whatever').elements.subscribe, 'function');
       assert.strictEqual(typeof html.select('whatever').events().subscribe, 'function');
       return {
         html: Rx.Observable.of(div('.test-element', ['Foobar']))
@@ -35,7 +35,7 @@ describe('HTML Driver', function () {
     let {sinks, sources, run} = Cycle(app, {
       html: makeHTMLDriver()
     });
-    sources.html.element$.subscribe(html => {
+    sources.html.elements.subscribe(html => {
       assert.strictEqual(html, '<div class="test-element">Foobar</div>');
       done();
     });
@@ -51,7 +51,7 @@ describe('HTML Driver', function () {
     let {sinks, sources, run} = Cycle(app, {
       html: makeHTMLDriver()
     });
-    sources.html.element$.subscribe(html => {
+    sources.html.elements.subscribe(html => {
       assert.strictEqual(html, '<div class="test-element">Foobar</div>');
       done();
     });
@@ -70,7 +70,7 @@ describe('HTML Driver', function () {
       let {sink, sources, run} = Cycle(app, {
         DOM: makeHTMLDriver({transposition: true})
       });
-      sources.DOM.element$.subscribe(html => {
+      sources.DOM.elements.subscribe(html => {
         assert.strictEqual(html,
           '<div class="test-element">' +
           '<h3 class="myelementclass"></h3>' +
@@ -96,7 +96,7 @@ describe('HTML Driver', function () {
         html: makeHTMLDriver({transposition: true})
       })
 
-      sources.html.element$.subscribe(html => {
+      sources.html.elements.subscribe(html => {
         assert.strictEqual(html,
           '<div class="test-element">' +
           '<div class="a-nice-element">' +
@@ -128,7 +128,7 @@ describe('HTML Driver', function () {
         DOM: makeHTMLDriver({transposition: true})
       });
 
-      sources.DOM.element$.subscribe(html => {
+      sources.DOM.elements.subscribe(html => {
         assert.strictEqual(html,
           '<div class="test-element">' +
           '<h3 class="myelementclass">YES</h3>' +
@@ -164,7 +164,7 @@ describe('HTML Driver', function () {
         html: makeHTMLDriver({transposition: true})
       });
 
-      sources.html.element$.subscribe(html => {
+      sources.html.elements.subscribe(html => {
         assert.strictEqual(html,
           '<div class="test-element">' +
             '<div>' +

--- a/test/node/mock-dom-source.js
+++ b/test/node/mock-dom-source.js
@@ -69,24 +69,24 @@ describe('mockDOMSource', function () {
       .subscribe(assert.fail, assert.fail, done);
   });
 
-  it('should return empty Observable for select().element$ and none is defined', function (done) {
+  it('should return empty Observable for select().elements and none is defined', function (done) {
     const userEvents = mockDOMSource({
       '.foo': {
         'click': Rx.Observable.just(135)
       }
     });
     let subscribeExecuted = false;
-    userEvents.select('.foo').element$
+    userEvents.select('.foo').elements
       .subscribe(assert.fail, assert.fail, done);
   });
 
-  it('should return defined Observable for select().element$', function (done) {
+  it('should return defined Observable for select().elements', function (done) {
     const mockedDOMSource = mockDOMSource({
       '.foo': {
-        element$: Rx.Observable.just(135)
+        elements: Rx.Observable.just(135)
       }
     });
-    mockedDOMSource.select('.foo').element$
+    mockedDOMSource.select('.foo').elements
       .subscribe(e => {
         assert.strictEqual(e, 135)
         done()
@@ -98,12 +98,12 @@ describe('mockDOMSource', function () {
       '.bar': {
         '.foo': {
           '.baz': {
-            element$: Rx.Observable.just(135)
+            elements: Rx.Observable.just(135)
           }
         }
       }
     });
-    mockedDOMSource.select('.bar').select('.foo').select('.baz').element$
+    mockedDOMSource.select('.bar').select('.foo').select('.baz').elements
       .subscribe(e => {
         assert.strictEqual(e, 135);
         done();
@@ -121,6 +121,6 @@ describe('mockDOMSource', function () {
     const DOM = mockDOMSource({})
     const selector = DOM.select('.something').select('.other')
     assert.strictEqual(selector.events('click') instanceof Rx.Observable, true)
-    assert.strictEqual(selector.element$ instanceof Rx.Observable, true)
+    assert.strictEqual(selector.elements instanceof Rx.Observable, true)
   })
 });


### PR DESCRIPTION
Creates a new snabbdom module, IsolateModule, that allows for keeping track of
isolated component boundaries.