### PR TITLE
Do not simulate bubbling for non-bubbling events

### DIFF
--- a/test/browser/events.js
+++ b/test/browser/events.js
@@ -333,7 +333,7 @@ describe('DOMSource.events()', function () {
       DOM: makeDOMDriver(createRenderTarget())
     });
 
-    sources.DOM.select('.parent').events('reset').subscribe(ev => {
+    sources.DOM.select('.form').events('reset').subscribe(ev => {
       assert.strictEqual(ev.type, 'reset');
       assert.strictEqual(ev.target.tagName, 'FORM');
       assert.strictEqual(ev.target.className, 'form');


### PR DESCRIPTION
Filter event streams that should not bubble with a simple check to whether or not it is an event that does not bubble.

Fix for cyclejs/core#291