### PR TITLE
Fix for isolated EventDelegators

### DIFF
--- a/src/DOMSource.ts
+++ b/src/DOMSource.ts
@@ -160,6 +160,9 @@ export class DOMSource {
           delegators.set(key, delegator);
         }
         const subject = xs.create<Event>();
+        if (scope) {
+          domSource._isolateModule.addEventDelegator(scope, delegator);
+        }
         delegator.addDestination(subject, namespace);
         return subject;
       })


### PR DESCRIPTION
When attaching event listners to elements other than the root element
supplied to makeDOMDriver(), the elements are likely to be removed
and recreated. This fix makes sure that EventDelegators always have
the latest element created by snabbdom for an isolation boundary.